### PR TITLE
MSDKUI-1638: Fix UI test memory leak

### DIFF
--- a/MSDKUI_Demo_UI_Tests/Impl/Utils/Utils.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Utils/Utils.swift
@@ -68,7 +68,7 @@ enum Utils {
     ///   - timeout: The timeout period in seconds.
     ///   - pollInterval: The polling interval period in seconds
     static func waitUntil(visible element: GREYMatcher,
-                          timeout: Double = Constants.longWait,
+                          timeout: Double = Constants.mediumWait,
                           pollInterval: Double = Constants.smallPollInterval) {
         // From the GREYMatchers::matcherForSufficientlyVisible() documentation:
         //    "EarlGrey considers elements that are more than kElementSufficientlyVisiblePercentage (75 %)

--- a/MSDKUI_Demo_UI_Tests/Impl/Views/DriveNavigation/DriveNavigationActions.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Views/DriveNavigation/DriveNavigationActions.swift
@@ -46,10 +46,10 @@ enum DriveNavigationActions {
 
     /// Dismisses alert if displayed on top.
     static func dismissAlert() {
-        let permissionAlertElement = grey_accessibilityID("LocationBasedViewController.AlertController.permissionsView")
+        let permissionAlertID = "LocationBasedViewController.AlertController.permissionsView"
 
-        Utils.waitUntil(visible: permissionAlertElement)
-        EarlGrey.selectElement(with: permissionAlertElement).perform(
+        Utils.waitUntil(visible: grey_accessibilityID(permissionAlertID))
+        EarlGrey.selectElement(with: grey_accessibilityID(permissionAlertID)).perform(
             GREYActionBlock.action(withName: "dismissAlert") { element, errorOrNil -> Bool in
                 // Check error, make sure we have view here, and make sure this is alert controller view
                 guard
@@ -60,7 +60,10 @@ enum DriveNavigationActions {
                 }
 
                 // Dismiss alert
-                alert.dismiss(animated: false)
+                alert.dismiss(animated: true)
+
+                // Wait until alert is not visible anymore
+                Utils.waitUntil(hidden: permissionAlertID)
 
                 return true
             }


### PR DESCRIPTION
- Fixed by properly dismissing the permission alert
- Also reverted element wait back to medium