### PR TITLE
MSDKUI-1649: Refactor GuidanceManeuverView to take a measurement formatter

### DIFF
--- a/MSDKUI/Classes/GuidanceManeuverData.swift
+++ b/MSDKUI/Classes/GuidanceManeuverData.swift
@@ -17,14 +17,14 @@
 import Foundation
 
 /// This struct holds all the data about a maneuver to be displayed on a `GuidanceManeuverView`
-/// object. Note that it conforms to the `Equatable` and `CustomStringConvertible` protocols.
-public struct GuidanceManeuverData {
+/// object.
+public struct GuidanceManeuverData: Equatable {
 
     /// The maneuver icon of the next maneuver.
     var maneuverIcon: String?
 
     /// The distance to the next maneuver.
-    var distance: String?
+    var distance: Measurement<UnitLength>?
 
     /// The info1 string which is mostly the next maneuver street.
     var info1: String?
@@ -34,26 +34,4 @@ public struct GuidanceManeuverData {
 
     /// The next road icon for this maneuver.
     var nextRoadIcon: UIImage?
-}
-
-// MARK: - Equatable
-
-extension GuidanceManeuverData: Equatable {
-
-    public static func == (lhs: GuidanceManeuverData, rhs: GuidanceManeuverData) -> Bool {
-        return lhs.maneuverIcon == rhs.maneuverIcon &&
-            lhs.distance == rhs.distance &&
-            lhs.info1 == rhs.info1 &&
-            lhs.info2 == rhs.info2 &&
-            lhs.nextRoadIcon == rhs.nextRoadIcon
-    }
-}
-
-// MARK: - CustomStringConvertible
-
-extension GuidanceManeuverData: CustomStringConvertible {
-
-    public var description: String {
-        return "maneuverIcon: \(maneuverIcon ?? "nil"), distance: \(distance ?? "nil"), info1: \(info1 ?? "nil"), info2: \(info2 ?? "nil")"
-    }
 }

--- a/MSDKUI/Classes/GuidanceManeuverData.swift
+++ b/MSDKUI/Classes/GuidanceManeuverData.swift
@@ -21,17 +21,17 @@ import Foundation
 public struct GuidanceManeuverData: Equatable {
 
     /// The maneuver icon of the next maneuver.
-    var maneuverIcon: String?
+    public var maneuverIcon: String?
 
     /// The distance to the next maneuver.
-    var distance: Measurement<UnitLength>?
+    public var distance: Measurement<UnitLength>?
 
     /// The info1 string which is mostly the next maneuver street.
-    var info1: String?
+    public var info1: String?
 
     /// The info2 string which is mostly the highway related information.
-    var info2: String?
+    public var info2: String?
 
     /// The next road icon for this maneuver.
-    var nextRoadIcon: UIImage?
+    public var nextRoadIcon: UIImage?
 }

--- a/MSDKUI/Classes/GuidanceManeuverData.swift
+++ b/MSDKUI/Classes/GuidanceManeuverData.swift
@@ -21,7 +21,7 @@ import Foundation
 public struct GuidanceManeuverData: Equatable {
 
     /// The maneuver icon of the next maneuver.
-    public var maneuverIcon: String?
+    public var maneuverIcon: UIImage?
 
     /// The distance to the next maneuver.
     public var distance: Measurement<UnitLength>?

--- a/MSDKUI/Classes/GuidanceManeuverMonitor.swift
+++ b/MSDKUI/Classes/GuidanceManeuverMonitor.swift
@@ -53,19 +53,14 @@ open class GuidanceManeuverMonitor: NSObject {
     /// Reference to the 'NMAPositioningManagerDidUpdatePosition' observer.
     private var positionUpdateObserver: NSObjectProtocol?
 
-    /// The measurement formatter used to format the distance to next maneuver.
-    private var measurementFormatter: MeasurementFormatter
-
     // MARK: - Public
 
     /// Creates and returns a `GuidanceManeuverMonitor` object.
     ///
     /// - Parameters:
     ///   - route: The route to be used.
-    ///   - measurementFormatter: The measurement formatter used to format the distance to next maneuver.
-    ///     The default value is `MeasurementFormatter.currentMediumUnitFormatter`.
-    public convenience init(route: NMARoute, measurementFormatter: MeasurementFormatter = .currentMediumUnitFormatter) {
-        self.init(route: route, notificationCenter: NotificationCenter.default, measurementFormatter: measurementFormatter)
+    public convenience init(route: NMARoute) {
+        self.init(route: route, notificationCenter: NotificationCenter.default)
     }
 
     /// Creates and returns a `GuidanceManeuverMonitor` object.
@@ -73,11 +68,9 @@ open class GuidanceManeuverMonitor: NSObject {
     /// - Parameters:
     ///   - route: The route to be used.
     ///   - notificationCenter: The notification center for observing position updates.
-    ///   - measurementFormatter: The measurement formatter used to format the distance to next maneuver.
-    init(route: NMARoute, notificationCenter: NotificationCenterObserving, measurementFormatter: MeasurementFormatter) {
+    init(route: NMARoute, notificationCenter: NotificationCenterObserving) {
         self.route = route
         self.notificationCenter = notificationCenter
-        self.measurementFormatter = measurementFormatter
 
         super.init()
 
@@ -123,11 +116,7 @@ open class GuidanceManeuverMonitor: NSObject {
         // Try to set the distance
         if NMAPositioningManager.sharedInstance().currentPosition != nil {
             let distanceValue = NMANavigationManager.sharedInstance().distanceToCurrentManeuver
-            let distance = Measurement(value: Double(distanceValue), unit: UnitLength.meters)
-
-            if distanceValue != NMANavigationManagerInvalidValue {
-                data.distance = measurementFormatter.string(from: distance)
-            }
+            data.distance = Measurement(value: Double(distanceValue), unit: UnitLength.meters)
         }
 
         // Try to set the info1 and info2 strings

--- a/MSDKUI/Classes/GuidanceManeuverMonitor.swift
+++ b/MSDKUI/Classes/GuidanceManeuverMonitor.swift
@@ -127,8 +127,10 @@ open class GuidanceManeuverMonitor: NSObject {
         data.info1 = maneuver.getSignpostExitNumber()
         data.info2 = maneuver.getNextStreet(fallback: route)
 
-        // Set the icon
-        data.maneuverIcon = maneuver.getIconFileName()
+        // Set the maneuver icon
+        data.maneuverIcon = maneuver.getIconFileName().flatMap {
+            UIImage(named: $0, in: .MSDKUI, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
+        }
 
         // Set the next road icon for this maneuver
         data.nextRoadIcon = maneuver.nextRoadIcon?.uiImage()

--- a/MSDKUI/Classes/GuidanceManeuverView.swift
+++ b/MSDKUI/Classes/GuidanceManeuverView.swift
@@ -339,9 +339,7 @@ import NMAKit
 
     private func displayData(data: GuidanceManeuverData) {
         if let maneuverIcon = data.maneuverIcon {
-            let image = UIImage(named: maneuverIcon, in: .MSDKUI, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
-
-            maneuverImageViews.forEach { $0.image = image }
+            maneuverImageViews.forEach { $0.image = maneuverIcon }
         }
 
         if let distance = data.distance {

--- a/MSDKUI/Classes/GuidanceManeuverView.swift
+++ b/MSDKUI/Classes/GuidanceManeuverView.swift
@@ -108,6 +108,10 @@ import NMAKit
         }
     }
 
+    public var distanceFormatter: MeasurementFormatter = .currentMediumUnitFormatter {
+        didSet { refreshView() }
+    }
+
     /// Sets the view's foreground color, i.e. the color for the icons, text and busy indicators.
     /// The default foreground color is colorForegroundLight.
     public var foregroundColor: UIColor = .colorForegroundLight {
@@ -341,7 +345,7 @@ import NMAKit
         }
 
         if let distance = data.distance {
-            distanceLabels.forEach { $0.text = distance }
+            distanceLabels.forEach { $0.text = distanceFormatter.string(from: distance) }
         }
 
         // Always set the road icon (since nextRoadIcon is optional)

--- a/MSDKUI_Tests/GuidanceManeuverDataTests.swift
+++ b/MSDKUI_Tests/GuidanceManeuverDataTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 final class GuidanceManeuverDataTests: XCTestCase {
 
-    private let maneuverIcon = "maneuver_icon_4"
+    private let maneuverIcon = UIImage()
     private let distance = Measurement(value: 300, unit: UnitLength.meters)
     private let info1 = "Exit 30"
     private let info2 = "Invalidenstr."

--- a/MSDKUI_Tests/GuidanceManeuverDataTests.swift
+++ b/MSDKUI_Tests/GuidanceManeuverDataTests.swift
@@ -20,7 +20,7 @@ import XCTest
 final class GuidanceManeuverDataTests: XCTestCase {
 
     private let maneuverIcon = "maneuver_icon_4"
-    private let distance = "300 m"
+    private let distance = Measurement(value: 300, unit: UnitLength.meters)
     private let info1 = "Exit 30"
     private let info2 = "Invalidenstr."
     private let nextRoadIcon = UIImage()
@@ -51,15 +51,5 @@ final class GuidanceManeuverDataTests: XCTestCase {
         let objectWithSameData = GuidanceManeuverData(maneuverIcon: maneuverIcon, distance: distance, info1: info1, info2: info2, nextRoadIcon: nextRoadIcon)
 
         XCTAssertEqual(objectWithSameData, dataObject, "Wrong equality!")
-    }
-
-    /// Tests that the string description works as expected.
-    func testDescription() {
-        let dataObject = GuidanceManeuverData(maneuverIcon: maneuverIcon, distance: distance, info1: nil, info2: info2, nextRoadIcon: nil)
-
-        let description = String(describing: dataObject)
-        let expectedDescription = "maneuverIcon: \(maneuverIcon), distance: \(distance), info1: nil, info2: \(info2)"
-
-        XCTAssertEqual(description, expectedDescription, "Wrong description!")
     }
 }

--- a/MSDKUI_Tests/GuidanceManeuverMonitorTests.swift
+++ b/MSDKUI_Tests/GuidanceManeuverMonitorTests.swift
@@ -92,7 +92,8 @@ final class GuidanceManeuverMonitorTests: XCTestCase {
     /// Tests when the delegate method `.navigationManager(_:didUpdateManeuvers:nextManeuver:)` is triggered.
     func testWhenNavigationManagerDidUpdateManeuversNextManeuverIsTriggered() {
         let expectedDistance = Measurement(value: 300, unit: UnitLength.meters)
-        let expectedGuidanceData = GuidanceManeuverData(maneuverIcon: "maneuver_icon_4",
+        let expectedManeuverIcon = UIImage(named: "maneuver_icon_4", in: .MSDKUI, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
+        let expectedGuidanceData = GuidanceManeuverData(maneuverIcon: expectedManeuverIcon,
                                                         distance: expectedDistance,
                                                         info1: nil,
                                                         info2: "Invalidenstr.",
@@ -121,7 +122,8 @@ final class GuidanceManeuverMonitorTests: XCTestCase {
     /// Tests when a `NMAPositioningManagerDidUpdatePosition` notification is received.
     func testWhenNMAPositioningManagerDidUpdatePositionNotificationIsReceived() {
         let expectedDistance = Measurement(value: 300, unit: UnitLength.meters)
-        let expectedGuidanceData = GuidanceManeuverData(maneuverIcon: "maneuver_icon_4",
+        let expectedManeuverIcon = UIImage(named: "maneuver_icon_4", in: .MSDKUI, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
+        let expectedGuidanceData = GuidanceManeuverData(maneuverIcon: expectedManeuverIcon,
                                                         distance: expectedDistance,
                                                         info1: nil,
                                                         info2: "Invalidenstr.",

--- a/MSDKUI_Tests/GuidanceManeuverMonitorTests.swift
+++ b/MSDKUI_Tests/GuidanceManeuverMonitorTests.swift
@@ -59,9 +59,6 @@ final class GuidanceManeuverMonitorTests: XCTestCase {
     /// The mock notification center used to verify expectations.
     private let mockNotificationCenter = NotificationCenterObservingMock()
 
-    /// The measurement formatter used to test the monitor.
-    private let measurementFormatter = MeasurementFormatter.currentMediumUnitFormatter
-
     override func setUp() {
         super.setUp()
 
@@ -69,9 +66,7 @@ final class GuidanceManeuverMonitorTests: XCTestCase {
         _ = GuidanceManeuverMonitorTests.setMethods
 
         // Set up
-        maneuverMonitor = GuidanceManeuverMonitor(route: MockUtils.mockRoute(),
-                                                  notificationCenter: mockNotificationCenter,
-                                                  measurementFormatter: measurementFormatter)
+        maneuverMonitor = GuidanceManeuverMonitor(route: MockUtils.mockRoute(), notificationCenter: mockNotificationCenter)
 
         maneuverMonitor?.delegate = mockDelegate
         GuidanceManeuverMonitorTests.swizzleMethods()
@@ -97,9 +92,8 @@ final class GuidanceManeuverMonitorTests: XCTestCase {
     /// Tests when the delegate method `.navigationManager(_:didUpdateManeuvers:nextManeuver:)` is triggered.
     func testWhenNavigationManagerDidUpdateManeuversNextManeuverIsTriggered() {
         let expectedDistance = Measurement(value: 300, unit: UnitLength.meters)
-        let expectedFormattedDistance = measurementFormatter.string(from: expectedDistance)
         let expectedGuidanceData = GuidanceManeuverData(maneuverIcon: "maneuver_icon_4",
-                                                        distance: expectedFormattedDistance,
+                                                        distance: expectedDistance,
                                                         info1: nil,
                                                         info2: "Invalidenstr.",
                                                         nextRoadIcon: nil)
@@ -127,9 +121,8 @@ final class GuidanceManeuverMonitorTests: XCTestCase {
     /// Tests when a `NMAPositioningManagerDidUpdatePosition` notification is received.
     func testWhenNMAPositioningManagerDidUpdatePositionNotificationIsReceived() {
         let expectedDistance = Measurement(value: 300, unit: UnitLength.meters)
-        let expectedFormattedDistance = measurementFormatter.string(from: expectedDistance)
         let expectedGuidanceData = GuidanceManeuverData(maneuverIcon: "maneuver_icon_4",
-                                                        distance: expectedFormattedDistance,
+                                                        distance: expectedDistance,
                                                         info1: nil,
                                                         info2: "Invalidenstr.",
                                                         nextRoadIcon: nil)

--- a/MSDKUI_Tests/GuidanceManeuverViewTests.swift
+++ b/MSDKUI_Tests/GuidanceManeuverViewTests.swift
@@ -49,7 +49,7 @@ final class GuidanceManeuverViewTests: XCTestCase {
     /// Tests the state of Data and NoData Containers after data is set.
     func testContainersStateWithDataSet() {
         // Sets the view data
-        view.data = GuidanceManeuverData(maneuverIcon: "maneuver_icon_11",
+        view.data = GuidanceManeuverData(maneuverIcon: UIImage(),
                                          distance: Measurement(value: 30, unit: UnitLength.meters),
                                          info1: "Exit 30",
                                          info2: "Invalidenstr.",
@@ -108,7 +108,7 @@ final class GuidanceManeuverViewTests: XCTestCase {
 
     /// Tests the view height when the Info1 is set in the portrait orientation.
     func testViewWithInfo1inPortrait() {
-        let data = GuidanceManeuverData(maneuverIcon: "maneuver_icon_11",
+        let data = GuidanceManeuverData(maneuverIcon: UIImage(),
                                         distance: Measurement(value: 30, unit: UnitLength.meters),
                                         info1: "Exit 30",
                                         info2: "Invalidenstr.",
@@ -132,7 +132,7 @@ final class GuidanceManeuverViewTests: XCTestCase {
 
     /// Tests the view when the Info1 is not set in the portrait orientation.
     func testViewWithoutInfo1inPortrait() {
-        let data = GuidanceManeuverData(maneuverIcon: "maneuver_icon_12",
+        let data = GuidanceManeuverData(maneuverIcon: UIImage(),
                                         distance: Measurement(value: 30, unit: UnitLength.meters),
                                         info1: nil,
                                         info2: "Invalidenstr.",

--- a/MSDKUI_Tests/GuidanceManeuverViewTests.swift
+++ b/MSDKUI_Tests/GuidanceManeuverViewTests.swift
@@ -50,7 +50,7 @@ final class GuidanceManeuverViewTests: XCTestCase {
     func testContainersStateWithDataSet() {
         // Sets the view data
         view.data = GuidanceManeuverData(maneuverIcon: "maneuver_icon_11",
-                                         distance: "30 m",
+                                         distance: Measurement(value: 30, unit: UnitLength.meters),
                                          info1: "Exit 30",
                                          info2: "Invalidenstr.",
                                          nextRoadIcon: mockNextRoadIcon)
@@ -109,7 +109,7 @@ final class GuidanceManeuverViewTests: XCTestCase {
     /// Tests the view height when the Info1 is set in the portrait orientation.
     func testViewWithInfo1inPortrait() {
         let data = GuidanceManeuverData(maneuverIcon: "maneuver_icon_11",
-                                        distance: "30 m",
+                                        distance: Measurement(value: 30, unit: UnitLength.meters),
                                         info1: "Exit 30",
                                         info2: "Invalidenstr.",
                                         nextRoadIcon: mockNextRoadIcon)
@@ -133,7 +133,7 @@ final class GuidanceManeuverViewTests: XCTestCase {
     /// Tests the view when the Info1 is not set in the portrait orientation.
     func testViewWithoutInfo1inPortrait() {
         let data = GuidanceManeuverData(maneuverIcon: "maneuver_icon_12",
-                                        distance: "200 m",
+                                        distance: Measurement(value: 30, unit: UnitLength.meters),
                                         info1: nil,
                                         info2: "Invalidenstr.",
                                         nextRoadIcon: mockNextRoadIcon)
@@ -216,6 +216,11 @@ final class GuidanceManeuverViewTests: XCTestCase {
     // MARK: - Private
 
     private func checkData(_ data: GuidanceManeuverData, line: UInt = #line) {
+        guard let distance = data.distance else {
+            XCTFail("Missing distance")
+            return
+        }
+
         XCTAssertNotNil(view.maneuverImageViews[GuidanceManeuverView.Orientation.portrait.rawValue].image,
                         "The portrait maneuver image is not set!",
                         line: line)
@@ -226,7 +231,7 @@ final class GuidanceManeuverViewTests: XCTestCase {
                        line: line)
 
         XCTAssertEqual(view.distanceLabels[GuidanceManeuverView.Orientation.portrait.rawValue].text,
-                       data.distance,
+                       MeasurementFormatter.currentMediumUnitFormatter.string(from: distance),
                        "The portrait distance data is wrong!",
                        line: line)
 
@@ -250,7 +255,7 @@ final class GuidanceManeuverViewTests: XCTestCase {
                        line: line)
 
         XCTAssertEqual(view.distanceLabels[GuidanceManeuverView.Orientation.landscape.rawValue].text,
-                       data.distance,
+                       MeasurementFormatter.currentMediumUnitFormatter.string(from: distance),
                        "The landscape distance data is wrong!",
                        line: line)
 


### PR DESCRIPTION
This pull request moves the `MeasurementFormatter` from `GuidanceManeuverMonitor` to `GuidanceManeuverView` and changes the `GuidanceManeuverData` to carry a `Measurement` instead of a `String` to represent the distance to next maneuver.

With this change, the VIew Controller conforming to the `GuidanceManeuverMonitorDelegate` protocol can intercept the `GuidanceManeuverData` and update the distance `Measurement` before passing it to the `GuidanceManeuverView`. This allows developers to force any unit they might want to display on the `GuidanceManeuverView` (which, by default, displays units based on the locale).

This pull request also changes the `GuidanceManeuverData.getter:maneuverIcon` from
`String?` to `UIImage?`, leaving the `GuidanceManeuverView` more independent and reusable.