### PR TITLE
MSDKUI-1654: Improve GuidanceManeuverData handling

### DIFF
--- a/MSDKUI/Classes/GuidanceManeuverView.swift
+++ b/MSDKUI/Classes/GuidanceManeuverView.swift
@@ -338,34 +338,30 @@ import NMAKit
     }
 
     private func displayData(data: GuidanceManeuverData) {
-        if let maneuverIcon = data.maneuverIcon {
-            maneuverImageViews.forEach { $0.image = maneuverIcon }
+        // Sets the maneuver icon
+        maneuverImageViews.forEach {
+            $0.image = data.maneuverIcon
         }
 
-        if let distance = data.distance {
-            distanceLabels.forEach { $0.text = distanceFormatter.string(from: distance) }
+        // Sets the distance text
+        distanceLabels.forEach {
+            $0.text = data.distance.map(distanceFormatter.string)
         }
 
-        // Always set the road icon (since nextRoadIcon is optional)
+        // Sets the road icon
         roadIconViews.forEach {
             $0.image = data.nextRoadIcon
         }
 
-        // Info1 is an optional string
-        if let info1 = data.info1 {
-            info1Labels.forEach {
-                $0.text = info1
-                $0.isHidden = false
-            }
-        } else {
-            info1Labels.forEach {
-                $0.text = nil
-                $0.isHidden = true
-            }
+        // Sets the info 1 and info 2 texts
+        info1Labels.forEach {
+            $0.text = data.info1
+            $0.isHidden = data.info1 == nil
         }
 
-        if let info2 = data.info2 {
-            info2Labels.forEach { $0.text = info2 }
+        info2Labels.forEach {
+            $0.text = data.info2
+            $0.isHidden = data.info2 == nil
         }
 
         // Sets the visibility of the two containers to display the maneuver data

--- a/MSDKUI_Tests/GuidanceManeuverViewTests.swift
+++ b/MSDKUI_Tests/GuidanceManeuverViewTests.swift
@@ -213,6 +213,101 @@ final class GuidanceManeuverViewTests: XCTestCase {
         checkStyle(backgroundColor: newBackgroundColor, foregroundColor: newForegroundColor)
     }
 
+    // MARK: - Guidance Maneuver Data
+
+    /// Tests the behavior when maneuverIcon is nil.
+    func testWhenManeuverIconIsNil() {
+        view.data = GuidanceManeuverData(maneuverIcon: nil, distance: nil, info1: nil, info2: nil, nextRoadIcon: nil)
+
+        XCTAssertFalse(view.maneuverImageViews.filter { $0.image == nil }.isEmpty,
+                       "It doesn't have maneuver image")
+    }
+
+    /// Tests the behavior when maneuverIcon is valid.
+    func testWhenManeuverIconIsValid() {
+        view.data = GuidanceManeuverData(maneuverIcon: UIImage(), distance: nil, info1: nil, info2: nil, nextRoadIcon: nil)
+
+        XCTAssertFalse(view.maneuverImageViews.filter { $0.image != nil }.isEmpty,
+                       "It has maneuver image")
+    }
+
+    /// Tests the behavior when distance is nil.
+    func testWhenDistanceIsNil() {
+        view.data = GuidanceManeuverData(maneuverIcon: nil, distance: nil, info1: nil, info2: nil, nextRoadIcon: nil)
+
+        XCTAssertFalse(view.distanceLabels.filter { $0.text == nil }.isEmpty,
+                       "It doesn't have distance text")
+    }
+
+    /// Tests the behavior when distance is valid.
+    func testWhenDistanceIsValid() {
+        let distance = Measurement(value: 30, unit: UnitLength.furlongs)
+        view.data = GuidanceManeuverData(maneuverIcon: nil, distance: distance, info1: nil, info2: nil, nextRoadIcon: nil)
+
+        XCTAssertFalse(view.distanceLabels.filter { $0.text != nil }.isEmpty,
+                       "It has distance text")
+    }
+
+    /// Tests the behavior when info1 is nil.
+    func testWhenInfo1IsNil() {
+        view.data = GuidanceManeuverData(maneuverIcon: nil, distance: nil, info1: nil, info2: nil, nextRoadIcon: nil)
+
+        XCTAssertFalse(view.info1Labels.filter { $0.text == nil }.isEmpty,
+                       "It doesn't have info1 text")
+
+        XCTAssertFalse(view.info1Labels.filter { $0.isHidden }.isEmpty,
+                       "It hides the info1 labels")
+    }
+
+    /// Tests the behavior when info1 is valid.
+    func testWhenInfo1IsValid() {
+        view.data = GuidanceManeuverData(maneuverIcon: nil, distance: nil, info1: "Foobar", info2: nil, nextRoadIcon: nil)
+
+        XCTAssertFalse(view.info1Labels.filter { $0.text != nil }.isEmpty,
+                       "It has info1 text")
+
+        XCTAssertTrue(view.info1Labels.filter { $0.isHidden }.isEmpty,
+                      "It shows the info1 labels")
+    }
+
+    /// Tests the behavior when info2 is nil.
+    func testWhenInfo2IsNil() {
+        view.data = GuidanceManeuverData(maneuverIcon: nil, distance: nil, info1: nil, info2: nil, nextRoadIcon: nil)
+
+        XCTAssertFalse(view.info2Labels.filter { $0.text == nil }.isEmpty,
+                       "It doesn't have info2 text")
+
+        XCTAssertFalse(view.info2Labels.filter { $0.isHidden }.isEmpty,
+                       "It hides the info2 labels")
+    }
+
+    /// Tests the behavior when info2 is valid.
+    func testWhenInfo2IsValid() {
+        view.data = GuidanceManeuverData(maneuverIcon: nil, distance: nil, info1: nil, info2: "Foobar", nextRoadIcon: nil)
+
+        XCTAssertFalse(view.info2Labels.filter { $0.text != nil }.isEmpty,
+                       "It has info2 text")
+
+        XCTAssertTrue(view.info2Labels.filter { $0.isHidden }.isEmpty,
+                      "It shows the info2 labels")
+    }
+
+    /// Tests the behavior when nextRoadIcon is nil.
+    func testWhenNextRoadIconIsNil() {
+        view.data = GuidanceManeuverData(maneuverIcon: nil, distance: nil, info1: nil, info2: nil, nextRoadIcon: nil)
+
+        XCTAssertFalse(view.roadIconViews.filter { $0.image == nil }.isEmpty,
+                       "It doesn't have road icon image")
+    }
+
+    /// Tests the behavior when nextRoadIcon is valid.
+    func testWhenNextRoadIconIsValid() {
+        view.data = GuidanceManeuverData(maneuverIcon: nil, distance: nil, info1: nil, info2: nil, nextRoadIcon: UIImage())
+
+        XCTAssertFalse(view.roadIconViews.filter { $0.image != nil }.isEmpty,
+                       "It has road icon image")
+    }
+
     // MARK: - Private
 
     private func checkData(_ data: GuidanceManeuverData, line: UInt = #line) {


### PR DESCRIPTION
The `GuidanceManeuverData` model contains nullable properties and, therefore, `GuidanceManeuverView` should reflect that.

Current implementation only updates the view if the values carried by `GuidanceManeuverData` are not `nil`. This creates a problem, since a new values with `nil` would keep previous view values.

This commit changes that. If a new model contains `nil`, the view will take that in consideration and reflect whatever the model has.

Signed-off-by: Otavio Cordeiro <41054361+otaviohere@users.noreply.github.com>