### PR TITLE
MSDKUI-1661: Rename GuidanceCurrentStreetLabel to GuidanceStreetLabel

### DIFF
--- a/MSDKUI.xcodeproj/project.pbxproj
+++ b/MSDKUI.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2B03B90721148B8300CA612C /* GuidanceCurrentStreetLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B03B90621148B8300CA612C /* GuidanceCurrentStreetLabelTests.swift */; };
+		2B03B90721148B8300CA612C /* GuidanceStreetLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B03B90621148B8300CA612C /* GuidanceStreetLabelTests.swift */; };
 		2B049B1F217632C90001F117 /* ExtensionArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B049B1E217632C90001F117 /* ExtensionArrayTests.swift */; };
 		2B09C2EB2178D95A00B90B23 /* MapViewportHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B09C2EA2178D95A00B90B23 /* MapViewportHandlerTests.swift */; };
 		2B2C50E4218B609A00227C29 /* DriveNavigationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2C50E3218B609A00227C29 /* DriveNavigationActions.swift */; };
@@ -247,7 +247,7 @@
 
 /* Begin PBXFileReference section */
 		1B5B63A0F20D885320D69345 /* Pods_MSDKUI_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MSDKUI_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2B03B90621148B8300CA612C /* GuidanceCurrentStreetLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceCurrentStreetLabelTests.swift; sourceTree = "<group>"; };
+		2B03B90621148B8300CA612C /* GuidanceStreetLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidanceStreetLabelTests.swift; sourceTree = "<group>"; };
 		2B049B1E217632C90001F117 /* ExtensionArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionArrayTests.swift; sourceTree = "<group>"; };
 		2B09C2EA2178D95A00B90B23 /* MapViewportHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewportHandlerTests.swift; sourceTree = "<group>"; };
 		2B2C50E3218B609A00227C29 /* DriveNavigationActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DriveNavigationActions.swift; sourceTree = "<group>"; };
@@ -777,7 +777,7 @@
 				62E110DE21246E42005D8063 /* ExtensionDateFormatterTests.swift */,
 				62E110E021246E4C005D8063 /* ExtensionMeasurementFormatterTests.swift */,
 				624E492221342E4D00D94D23 /* ExtensionNumberFormatterTests.swift */,
-				2B03B90621148B8300CA612C /* GuidanceCurrentStreetLabelTests.swift */,
+				2B03B90621148B8300CA612C /* GuidanceStreetLabelTests.swift */,
 				2B31F6B7212E989E007B760B /* GuidanceCurrentStreetNameMonitorTests.swift */,
 				628740C021237CF000BCD03E /* GuidanceEstimatedArrivalMonitorTests.swift */,
 				62CFD6B82122CAD200E77A69 /* GuidanceEstimatedArrivalViewTests.swift */,
@@ -1558,7 +1558,7 @@
 				62D4B280216B92CF009744BF /* OptionsPanelDelegateMock.swift in Sources */,
 				62D392CE20E9100E006E963D /* NMAMapViewPartialMock.swift in Sources */,
 				5A61A56D1F0664A300470BE9 /* WaypointListTests.swift in Sources */,
-				2B03B90721148B8300CA612C /* GuidanceCurrentStreetLabelTests.swift in Sources */,
+				2B03B90721148B8300CA612C /* GuidanceStreetLabelTests.swift in Sources */,
 				5A16301B208F693100E61B07 /* GuidanceManeuverViewTests.swift in Sources */,
 				5A09DBFE1F296B15006EBED7 /* TravelTimePickerTests.swift in Sources */,
 				5A1B2AA320A09A8D009AD672 /* GuidanceManeuverUtilTests.swift in Sources */,

--- a/MSDKUI/Classes/GuidanceStreetLabel.swift
+++ b/MSDKUI/Classes/GuidanceStreetLabel.swift
@@ -17,9 +17,9 @@
 import Foundation
 import UIKit
 
-/// Label for displaying the current street name,
+/// Label for displaying the street name,
 /// which depends on position and map tracking data.
-@IBDesignable open class GuidanceCurrentStreetLabel: UILabel {
+@IBDesignable open class GuidanceStreetLabel: UILabel {
 
     // MARK: - Properties
 
@@ -118,7 +118,7 @@ import UIKit
         updateBackgroundColor()
 
         // Accessibility
-        accessibilityIdentifier = String(reflecting: GuidanceCurrentStreetLabel.self)
+        accessibilityIdentifier = String(reflecting: GuidanceStreetLabel.self)
     }
 
     private func updateIsLookingForPosition() {

--- a/MSDKUI_Demo/GuidanceViewController.swift
+++ b/MSDKUI_Demo/GuidanceViewController.swift
@@ -54,7 +54,7 @@ final class GuidanceViewController: UIViewController {
     @IBOutlet private(set) var mapOverlayView: UIView!
 
     /// The current street label view which is initially hidden.
-    @IBOutlet private(set) var currentStreetLabel: GuidanceCurrentStreetLabel!
+    @IBOutlet private(set) var currentStreetLabel: GuidanceStreetLabel!
 
     @IBOutlet private(set) var currentSpeedView: GuidanceSpeedView!
 

--- a/MSDKUI_Demo/Storyboards/DriveNavigation.storyboard
+++ b/MSDKUI_Demo/Storyboards/DriveNavigation.storyboard
@@ -392,7 +392,7 @@
                                     <constraint firstItem="VN7-Kw-amw" firstAttribute="centerX" secondItem="c7a-Tq-RVu" secondAttribute="centerX" id="OQG-3F-Fvg"/>
                                 </constraints>
                             </stackView>
-                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DoP-zY-A0Y" customClass="GuidanceCurrentStreetLabel" customModule="MSDKUI">
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DoP-zY-A0Y" customClass="GuidanceStreetLabel" customModule="MSDKUI">
                                 <rect key="frame" x="300" y="472" width="0.0" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="32" id="PiV-ck-Rf4"/>

--- a/MSDKUI_Demo_UI_Tests/Impl/Views/DriveNavigation/DriveNavigationActions.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Views/DriveNavigation/DriveNavigationActions.swift
@@ -435,13 +435,13 @@ enum DriveNavigationActions {
         return (labelColor, viewBackgroundColor)
     }
 
-    /// Method that is getting `GuidanceCurrentStreetLabel` object.
+    /// Method that is getting `GuidanceStreetLabel` object.
     /// - Returns: current streel label object or nil if cannot be find.
-    static func getCurrentStreetLabel() -> GuidanceCurrentStreetLabel? {
-        var currentStreetLabel: GuidanceCurrentStreetLabel?
+    static func getCurrentStreetLabel() -> GuidanceStreetLabel? {
+        var currentStreetLabel: GuidanceStreetLabel?
         EarlGrey.selectElement(with: DriveNavigationMatchers.currentStreetLabel).perform(
             GREYActionBlock.action(withName: "Get street label") { element, errorOrNil -> Bool in
-                guard errorOrNil != nil, let streetLabel = element as? GuidanceCurrentStreetLabel else {
+                guard errorOrNil != nil, let streetLabel = element as? GuidanceStreetLabel else {
                     return false
                 }
 

--- a/MSDKUI_Tests/GuidanceStreetLabelTests.swift
+++ b/MSDKUI_Tests/GuidanceStreetLabelTests.swift
@@ -17,15 +17,15 @@
 @testable import MSDKUI
 import XCTest
 
-final class GuidanceCurrentStreetLabelTests: XCTestCase {
+final class GuidanceStreetLabelTests: XCTestCase {
 
     /// The object under test.
-    private var labelUnderTest: GuidanceCurrentStreetLabel?
+    private var labelUnderTest: GuidanceStreetLabel?
 
     override func setUp() {
         super.setUp()
 
-        labelUnderTest = GuidanceCurrentStreetLabel(frame: .zero)
+        labelUnderTest = GuidanceStreetLabel(frame: .zero)
     }
 
     // MARK: - Looking for position state
@@ -119,7 +119,7 @@ final class GuidanceCurrentStreetLabelTests: XCTestCase {
         var labelUnderTest = try require(self.labelUnderTest)
         assertStyleProperties(of: labelUnderTest)
 
-        labelUnderTest = try require(GuidanceCurrentStreetLabel(coder: NSKeyedUnarchiver(forReadingWith: NSKeyedArchiver().encodedData)))
+        labelUnderTest = try require(GuidanceStreetLabel(coder: NSKeyedUnarchiver(forReadingWith: NSKeyedArchiver().encodedData)))
         assertStyleProperties(of: labelUnderTest)
     }
 
@@ -130,18 +130,18 @@ final class GuidanceCurrentStreetLabelTests: XCTestCase {
         var labelUnderTest = try require(self.labelUnderTest)
         assertAccessibility(of: labelUnderTest)
 
-        labelUnderTest = try require(GuidanceCurrentStreetLabel(coder: NSKeyedUnarchiver(forReadingWith: NSKeyedArchiver().encodedData)))
+        labelUnderTest = try require(GuidanceStreetLabel(coder: NSKeyedUnarchiver(forReadingWith: NSKeyedArchiver().encodedData)))
         assertAccessibility(of: labelUnderTest)
     }
 
     // MARK: - Private
 
-    private func assertAccessibility(of labelUnderTest: GuidanceCurrentStreetLabel) {
-        XCTAssertEqual(labelUnderTest.accessibilityIdentifier, "MSDKUI.GuidanceCurrentStreetLabel",
+    private func assertAccessibility(of labelUnderTest: GuidanceStreetLabel) {
+        XCTAssertEqual(labelUnderTest.accessibilityIdentifier, "MSDKUI.GuidanceStreetLabel",
                        "It has correct accessibility identifier")
     }
 
-    private func assertStyleProperties(of labelUnderTest: GuidanceCurrentStreetLabel) {
+    private func assertStyleProperties(of labelUnderTest: GuidanceStreetLabel) {
         XCTAssertTrue(labelUnderTest.isAccented, "It has correct style state")
         XCTAssertEqual(labelUnderTest.backgroundColor, .colorPositive, "It has correct background color")
         XCTAssertEqual(labelUnderTest.font, .preferredFont(forTextStyle: .subheadline), "It has correct font")


### PR DESCRIPTION

Since GuidanceCurrentStreetLabel can be used to show any street, not only the
current one, the name of this class should not be associated with it.

The current street data is provided by GuidanceCurrentStreetNameMonitor which
keeps its name.

In GuidanceViewController the GuidanceStreetLabel is paired with
GuidanceCurrentStreetNameMonitor, thus related variable and function names
should keep existing naming.

- renames class name and swift file from GuidanceCurrentStreetLabel to
  GuidanceStreetLabel
- renames class name and swift file from GuidanceCurrentStreetLabelTests to
  GuidanceStreetLabelTests
- updates GuidanceStreetLabel class summary

Signed-off-by: Piotr Marczycki <piotrekm44@users.noreply.github.com>