### PR TITLE
MSDKUI-1693: Remove safe area layout guide for GuidanceSpeedView

### DIFF
--- a/MSDKUI/Assets/GuidanceSpeedView.xib
+++ b/MSDKUI/Assets/GuidanceSpeedView.xib
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -46,17 +45,16 @@
                 </stackView>
             </subviews>
             <constraints>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="I7C-Ya-R55" secondAttribute="bottom" id="IoB-ny-YJO"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="I7C-Ya-R55" secondAttribute="trailing" id="JGO-Nl-AhA"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="I7C-Ya-R55" secondAttribute="bottom" id="IoB-ny-YJO"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="I7C-Ya-R55" secondAttribute="trailing" id="JGO-Nl-AhA"/>
                 <constraint firstItem="I7C-Ya-R55" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="VgR-vL-0Mr"/>
                 <constraint firstItem="I7C-Ya-R55" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="Xtj-gW-w2h"/>
-                <constraint firstItem="I7C-Ya-R55" firstAttribute="top" relation="greaterThanOrEqual" secondItem="vUN-kp-3ea" secondAttribute="top" id="aIe-fc-Mtx"/>
-                <constraint firstItem="I7C-Ya-R55" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="vUN-kp-3ea" secondAttribute="leading" id="fCL-Bx-Dmt"/>
+                <constraint firstItem="I7C-Ya-R55" firstAttribute="top" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="top" id="aIe-fc-Mtx"/>
+                <constraint firstItem="I7C-Ya-R55" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="leading" id="fCL-Bx-Dmt"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="-195" y="-517"/>
         </view>
     </objects>


### PR DESCRIPTION
Removed safe area layout guide to keep the view's content visible when
the GuidanceSpeedView is laid out of its ancestors' safe area

Signed-off-by: Piotr Marczycki <piotrekm44@users.noreply.github.com>