### PR TITLE
MSDKUI-1704: Fix GuidanceNextManeuverView "empty" state

### DIFF
--- a/MSDKUI/Assets/GuidanceNextManeuverView.xib
+++ b/MSDKUI/Assets/GuidanceNextManeuverView.xib
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,12 +18,12 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB">
+        <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="375" height="48"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="R9j-N6-b1B">
-                    <rect key="frame" x="20" y="8" width="335" height="32"/>
+                <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="R9j-N6-b1B">
+                    <rect key="frame" x="16" y="8" width="343" height="32"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TUk-YB-RZY">
                             <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
@@ -65,7 +64,7 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Street" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1fM-b3-8Pq" userLabel="Street Name Label">
-                            <rect key="frame" x="133" y="6" width="202" height="20.5"/>
+                            <rect key="frame" x="133" y="6" width="210" height="20.5"/>
                             <accessibility key="accessibilityConfiguration">
                                 <bool key="isElement" value="NO"/>
                             </accessibility>
@@ -78,15 +77,15 @@
             </subviews>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstItem="R9j-N6-b1B" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="10q-UL-sRw"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="R9j-N6-b1B" secondAttribute="bottom" constant="8" id="59j-Mc-8xg"/>
-                <constraint firstItem="R9j-N6-b1B" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="8" id="Hiu-Bj-M1w"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="R9j-N6-b1B" secondAttribute="trailing" constant="20" id="NfA-nZ-KRq"/>
+                <constraint firstAttribute="bottomMargin" secondItem="R9j-N6-b1B" secondAttribute="bottom" id="N2j-1k-kpp"/>
+                <constraint firstAttribute="trailingMargin" secondItem="R9j-N6-b1B" secondAttribute="trailing" id="WrI-bY-wBZ"/>
+                <constraint firstItem="R9j-N6-b1B" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="topMargin" id="fTx-Ec-a2J"/>
+                <constraint firstItem="R9j-N6-b1B" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" id="msq-pu-gNw"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
             <point key="canvasLocation" x="-140" y="-270.5"/>
         </view>
     </objects>

--- a/MSDKUI/Classes/GuidanceNextManeuverView.swift
+++ b/MSDKUI/Classes/GuidanceNextManeuverView.swift
@@ -127,6 +127,8 @@ import UIKit
 
     /// Sets up the view.
     private func setUpView() {
+        layoutMargins = .zero
+
         loadFromNib()
         setUpLabels()
         setUpViewAccessibility()

--- a/MSDKUI_Demo/GuidanceViewController.swift
+++ b/MSDKUI_Demo/GuidanceViewController.swift
@@ -163,6 +163,9 @@ final class GuidanceViewController: UIViewController {
         // Applies speed limit style
         setUpSpeedLimitView()
 
+        // Applies next maneuver view style
+        setUpNextManeuverView()
+
         guard let route = route else {
             return
         }
@@ -350,6 +353,12 @@ final class GuidanceViewController: UIViewController {
         // Adds red border
         speedLimitView.layer.borderWidth = 4
         speedLimitView.layer.borderColor = UIColor.red.cgColor
+    }
+
+    /// Styles the next maneuver view.
+    private func setUpNextManeuverView() {
+        // Sets margins for view
+        nextManeuverView.layoutMargins = UIEdgeInsets(top: 8, left: 20, bottom: 8, right: 20)
     }
 
     private func setUpPositionNotificationsObservers() {


### PR DESCRIPTION
This change removes margins added inside GuidanceNextManeuverView,
that causes displaying only empty background when no data is set.

Right now view itself does not contain margins, they need to be set
by using .layoutMargins property of view.