### PR TITLE
MSDKUI-1707: Remove icon view when not available in next maneuver view

### DIFF
--- a/MSDKUI/Assets/GuidanceNextManeuverView.xib
+++ b/MSDKUI/Assets/GuidanceNextManeuverView.xib
@@ -13,6 +13,7 @@
             <connections>
                 <outlet property="distanceLabel" destination="sCU-qM-EZl" id="yY3-K1-Hr1"/>
                 <outlet property="maneuverImageView" destination="p0e-Lb-zDt" id="hXK-iT-eFc"/>
+                <outlet property="maneuverImageViewContainer" destination="TUk-YB-RZY" id="Hwe-d0-9Cp"/>
                 <outlet property="separatorLabel" destination="Al9-lS-4w7" id="wib-7r-khE"/>
                 <outlet property="streetNameLabel" destination="1fM-b3-8Pq" id="2Oi-8G-jCV"/>
             </connections>

--- a/MSDKUI/Classes/GuidanceNextManeuverView.swift
+++ b/MSDKUI/Classes/GuidanceNextManeuverView.swift
@@ -54,6 +54,9 @@ import UIKit
 
     // MARK: - Properties
 
+    /// Container view of the next maneuver icon.
+    @IBOutlet private(set) weak var maneuverImageViewContainer: UIView!
+
     /// Image view for the icon of the next manuever.
     @IBOutlet private(set) weak var maneuverImageView: UIImageView!
 
@@ -103,10 +106,18 @@ import UIKit
     ///
     /// - Parameter model: The model used to configure the view.
     public func configure(with model: ViewModel) {
-        maneuverImageView.image = model.maneuverIcon
         maneuverImageView.tintColor = foregroundColor
         distanceLabel.text = model.distanceFormatter.string(from: model.distance)
         distanceLabel.sizeToFit()
+
+        // When icon is nil, it should be removed (not visible, giving space to the rest of the views)
+        if let icon = model.maneuverIcon {
+            maneuverImageViewContainer.isHidden = false
+            maneuverImageView.image = icon
+        } else {
+            maneuverImageViewContainer.isHidden = true
+            maneuverImageView.image = nil
+        }
 
         // When ViewModel.streetName is nil, the dot & street name label's should be hidden
         if let streetName = model.streetName {

--- a/MSDKUI_Tests/GuidanceNextManeuverViewTests.swift
+++ b/MSDKUI_Tests/GuidanceNextManeuverViewTests.swift
@@ -62,7 +62,7 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
 
     // MARK: - Configure
 
-    /// Tests if the subview vsibilities are correct when model is populated with a complete model.
+    /// Tests if the subview visibilities are correct when model is populated with a complete model.
     func testSubviewVisibilitiesWhenModelIsComplete() {
         let distance = Measurement<UnitLength>(value: 100, unit: .meters)
         let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(),
@@ -71,13 +71,14 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
 
         nextManeuverView.configure(with: viewModel)
 
+        XCTAssertFalse(nextManeuverView.maneuverImageViewContainer.isHidden, "The container of maneuver icon is visible")
         XCTAssertFalse(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is visible")
         XCTAssertFalse(nextManeuverView.distanceLabel.isHidden, "The distance label is visible")
         XCTAssertFalse(nextManeuverView.separatorLabel.isHidden, "The separator label is visible")
         XCTAssertFalse(nextManeuverView.streetNameLabel.isHidden, "The street name label is visible")
     }
 
-    /// Tests if the subview vsibilities are correct when model is populated with an incomplete model.
+    /// Tests if the subview visibilities are correct when model is populated with an incomplete model.
     func testSubviewVisibilitiesWhenModelIsIncomplete() {
         let distance = Measurement<UnitLength>(value: 100, unit: .meters)
         let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(),
@@ -86,10 +87,27 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
 
         nextManeuverView.configure(with: viewModel)
 
+        XCTAssertFalse(nextManeuverView.maneuverImageViewContainer.isHidden, "The container of maneuver icon is visible")
         XCTAssertFalse(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is visible")
         XCTAssertFalse(nextManeuverView.distanceLabel.isHidden, "The distance label is visible")
         XCTAssertTrue(nextManeuverView.separatorLabel.isHidden, "The separator label is hidden")
         XCTAssertTrue(nextManeuverView.streetNameLabel.isHidden, "The street name label is hidden")
+    }
+
+    /// Tests if container image view is hidden when model is populated without icon view.
+    func testIconVisibilityWhenNotAvailable() {
+        let distance = Measurement<UnitLength>(value: 100, unit: .meters)
+        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: nil,
+                                                           distance: distance,
+                                                           streetName: "Invalidenstr.")
+
+        nextManeuverView.configure(with: viewModel)
+
+        XCTAssertTrue(nextManeuverView.maneuverImageViewContainer.isHidden, "The container of maneuver icon is hidden")
+        XCTAssertFalse(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is visible")
+        XCTAssertFalse(nextManeuverView.distanceLabel.isHidden, "The distance label is visible")
+        XCTAssertFalse(nextManeuverView.separatorLabel.isHidden, "The separator label is visible")
+        XCTAssertFalse(nextManeuverView.streetNameLabel.isHidden, "The street name label is visible")
     }
 
     // MARK: - Accessibility


### PR DESCRIPTION
When next maneuver has no icon, it should not preserve empty space,
so the text can be aligned to the left side of the view.

Signed-off-by: Piotr Szmyt <8458314+PiotrSzmyt@users.noreply.github.com>