### PR TITLE
MSDKUI-1729: Integrate HEREMaps 3.10

### DIFF
--- a/Commons_Tests/Mocks/NMANavigationManagerDelegateMock.swift
+++ b/Commons_Tests/Mocks/NMANavigationManagerDelegateMock.swift
@@ -24,6 +24,7 @@ final class NMANavigationManagerDelegateMock: NSObject {
     // Properties used for verifying expectations.
     private(set) var lastNavigationManager: NMANavigationManager?
     private(set) var lastCurrentManeuver: NMAManeuver?
+    private(set) var lastError: NMARoutingError?
     private(set) var lastNextManeuver: NMAManeuver?
     private(set) var lastStopOver: NMAWaypoint?
     private(set) var lastRouteResult: NMARouteResult?
@@ -121,8 +122,9 @@ extension NMANavigationManagerDelegateMock: NMANavigationManagerDelegate {
         lastNavigationManager = navigationManager
     }
 
-    public func navigationManagerDidReroute(_ navigationManager: NMANavigationManager) {
+    public func navigationManager(_ navigationManager: NMANavigationManager, didRerouteWithError error: NMARoutingError) {
         lastNavigationManager = navigationManager
+        lastError = error
     }
 
     public func navigationManager(_ navigationManager: NMANavigationManager, didFindAlternateRoute routeResult: NMARouteResult) {

--- a/HEREMapsUI.podspec
+++ b/HEREMapsUI.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
     s.resource_bundles      = {
         'MSDKUI' => ['MSDKUI/Assets/*.png', 'MSDKUI/Assets/*.xib', 'MSDKUI/Assets/*.lproj']
     }
-    s.dependency            'HEREMaps', '3.9'
+    s.dependency            'HEREMaps', '3.10'
 end

--- a/MSDKUI/Classes/NavigationManagerDelegateDispatcher.swift
+++ b/MSDKUI/Classes/NavigationManagerDelegateDispatcher.swift
@@ -201,9 +201,9 @@ extension NavigationManagerDelegateDispatcher: NMANavigationManagerDelegate {
         updateNavigationManagerDelegate()
     }
 
-    public func navigationManagerDidReroute(_ navigationManager: NMANavigationManager) {
+    public func navigationManager(_ navigationManager: NMANavigationManager, didRerouteWithError error: NMARoutingError) {
         delegates.invoke {
-            $0.navigationManagerDidReroute?(navigationManager)
+            $0.navigationManager?(navigationManager, didRerouteWithError: error)
         }
 
         updateNavigationManagerDelegate()

--- a/MSDKUI_Demo_Tests/View Controllers/AboutTableViewDataSourceTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/AboutTableViewDataSourceTests.swift
@@ -65,7 +65,7 @@ final class AboutTableViewDataSourceTests: XCTestCase {
         // Third item
         let thirdItem = try require(dataSource?.item(at: IndexPath(row: 2, section: 0)))
         XCTAssertLocalized(thirdItem.title, key: "msdkui_app_here_sdk_version", "It has the correct title")
-        XCTAssertTrue(thirdItem.description.contains("3.9.0"), "It has the correct description")
+        XCTAssertTrue(thirdItem.description.contains("3.10.0"), "It has the correct description")
 
         // Fourth item
         let fourthItem = try require(dataSource?.item(at: IndexPath(row: 3, section: 0)))

--- a/MSDKUI_Tests/NavigationManagerDelegateDispatcherTests.swift
+++ b/MSDKUI_Tests/NavigationManagerDelegateDispatcherTests.swift
@@ -386,13 +386,15 @@ final class NavigationManagerDelegateDispatcherTests: XCTestCase {
         dispatcherUnderTest.add(delegate: mockDelegateB)
 
         // Triggers the method
-        dispatcherUnderTest.navigationManagerDidReroute(.sharedInstance())
+        dispatcherUnderTest.navigationManager(.sharedInstance(), didRerouteWithError: .unknown)
 
         XCTAssertTrue(mockDelegateA.lastNavigationManager === NMANavigationManager.sharedInstance(),
                       "It calls the delegate method with the correct navigation manager.")
+        XCTAssertEqual(mockDelegateA.lastError, .unknown, "It calls the delegate method with the correct error.")
 
         XCTAssertTrue(mockDelegateB.lastNavigationManager === NMANavigationManager.sharedInstance(),
                       "It calls the delegate method with the correct navigation manager.")
+        XCTAssertEqual(mockDelegateB.lastError, .unknown, "It calls the delegate method with the correct error.")
     }
 
     /// Tests when the method `.navigationManager(_:didChangeRoutingState:)` is triggered.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - EarlGrey (1.15.0)
-  - HEREMaps (3.9.0)
+  - HEREMaps (3.10.0)
   - HEREMapsUI (2.0.0):
-    - HEREMaps (= 3.9)
+    - HEREMaps (= 3.10)
   - OCMock (3.4.1)
   - SwiftLint (0.29.3)
 
@@ -25,8 +25,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   EarlGrey: 289a16cc7d08a54b962d72881b21e36d5103b549
-  HEREMaps: ce39da9e661d5c7358ae832d29107072b99f3738
-  HEREMapsUI: 716fd541b00e9492cc883146e81c2504cc4a9ef8
+  HEREMaps: f69e41d3830d5ca885b00082db0d47a39dbebf1f
+  HEREMapsUI: b8e3f1c204a66e12945aae6e86fd313f4f765e15
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
   SwiftLint: bfa7ca7b4d170cfaf0d236ca3ffd969e88a2f002
 


### PR DESCRIPTION
- updates HEREMapsUI dependency version of HEREMaps
- updates unit test checking against integrated HEREMaps version
- updates project's cocoapods dependencies
- changes deprecated navigation manager did reroute function
  to suggested replacement

Signed-off-by: Piotr Marczycki <piotrekm44@users.noreply.github.com>