### PR TITLE
MSDKUI-1690: Fix VoiceOver reads feet and yards incorrectly

### DIFF
--- a/MSDKUI/Classes/ExtensionMeasurementFormatter.swift
+++ b/MSDKUI/Classes/ExtensionMeasurementFormatter.swift
@@ -28,6 +28,16 @@ public extension MeasurementFormatter {
         formatter.numberFormatter.maximumFractionDigits = 0
         return formatter
     }()
+
+    /// Returns a `MeasurementFormatter` for reading units using current locale.
+    static let currentLongUnitFormatter: MeasurementFormatter = {
+        let formatter = MeasurementFormatter()
+        formatter.unitOptions = .naturalScale
+        formatter.unitStyle = .long
+        formatter.locale = .current
+        formatter.numberFormatter.maximumFractionDigits = 0
+        return formatter
+    }()
 }
 
 extension MeasurementFormatter {

--- a/MSDKUI/Classes/GuidanceNextManeuverView.swift
+++ b/MSDKUI/Classes/GuidanceNextManeuverView.swift
@@ -30,6 +30,7 @@ import UIKit
         var distance: Measurement<UnitLength>
         var streetName: String?
         var distanceFormatter: MeasurementFormatter
+        var accessibilityDistanceFormatter: MeasurementFormatter
 
         // MARK: - Public
 
@@ -41,14 +42,19 @@ import UIKit
         ///   - streetName: The name of the next maneuver street to be displayed.
         ///   - distanceFormatter: The `MeasurementFormatter` used to format the distance information.
         ///     The default value: Uses `MeasurementFormatter.currentMediumUnitFormatter`.
+        ///   - accessibilityDistanceFormatter: The `MeasurementFormatter` used to format
+        ///                                     the distance information for accessibility VoiceOver.
+        ///     The default value: Uses `MeasurementFormatter.currentLongUnitFormatter`.
         public init(maneuverIcon: UIImage?,
                     distance: Measurement<UnitLength>,
                     streetName: String?,
-                    distanceFormatter: MeasurementFormatter = .currentMediumUnitFormatter) {
+                    distanceFormatter: MeasurementFormatter = .currentMediumUnitFormatter,
+                    accessibilityDistanceFormatter: MeasurementFormatter = .currentLongUnitFormatter) {
             self.maneuverIcon = maneuverIcon
             self.distance = distance
             self.streetName = streetName
             self.distanceFormatter = distanceFormatter
+            self.accessibilityDistanceFormatter = accessibilityDistanceFormatter
         }
     }
 
@@ -108,6 +114,7 @@ import UIKit
     public func configure(with model: ViewModel) {
         maneuverImageView.tintColor = foregroundColor
         distanceLabel.text = model.distanceFormatter.string(from: model.distance)
+        distanceLabel.accessibilityLabel = model.accessibilityDistanceFormatter.string(from: model.distance)
         distanceLabel.sizeToFit()
 
         // When icon is nil, it should be removed (not visible, giving space to the rest of the views)

--- a/MSDKUI/Classes/ManeuverItemView.swift
+++ b/MSDKUI/Classes/ManeuverItemView.swift
@@ -234,7 +234,12 @@ import NMAKit
     ///   - maneuvers: All `NMAManeuver` elements of route.
     ///   - index: The index to get the maneuver from the given array.
     ///   - measurementFormatter: The measurement formatter used to format the distance.
-    public func setManeuver(maneuvers: [NMAManeuver], index: Int, measurementFormatter: MeasurementFormatter = .currentMediumUnitFormatter) {
+    ///   - accessibilityMeasurementFormatter: The measurement formatter used to format
+    ///     the distance for accessibility VoiceOver.
+    public func setManeuver(maneuvers: [NMAManeuver],
+                            index: Int,
+                            measurementFormatter: MeasurementFormatter = .currentMediumUnitFormatter,
+                            accessibilityMeasurementFormatter: MeasurementFormatter = .currentLongUnitFormatter) {
         setUpStyle()
 
         maneuver = maneuvers.indices.contains(index) ? maneuvers[index] : nil
@@ -259,6 +264,7 @@ import NMAKit
         } else {
             let distance = Measurement(value: Double(distanceValue), unit: UnitLength.meters)
             distanceLabel.text = measurementFormatter.string(from: distance)
+            distanceLabel.accessibilityLabel = accessibilityMeasurementFormatter.string(from: distance)
         }
 
         if let iconFileName = maneuverResources.getIconFileName(for: index) {

--- a/MSDKUI/Classes/RouteDescriptionItem.swift
+++ b/MSDKUI/Classes/RouteDescriptionItem.swift
@@ -382,6 +382,7 @@ import NMAKit
             durationLabel.text = handler.duration
             delayLabel.text = handler.trafficDelay
             lengthLabel.text = handler.length
+            lengthLabel.accessibilityLabel = handler.longFormatLength
             timeLabel.text = handler.arrivalTime
 
             // If there is a delay, `delayLabel` should use the
@@ -463,7 +464,7 @@ import NMAKit
 
             if isSectionVisible(.length) {
                 hint.appendComma()
-                hint += String(format: "msdkui_route_length".localized, arguments: [handler.length])
+                hint += String(format: "msdkui_route_length".localized, arguments: [handler.longFormatLength])
             }
 
             if isSectionVisible(.time) {

--- a/MSDKUI/Classes/RouteDescriptionItemHandler.swift
+++ b/MSDKUI/Classes/RouteDescriptionItemHandler.swift
@@ -133,6 +133,12 @@ struct RouteDescriptionItemHandler {
         return MeasurementFormatter.currentMediumUnitFormatter.string(from: distance)
     }
 
+    /// Length of the route using current locale, natural scale and long style.
+    var longFormatLength: String {
+        let distance = Measurement(value: Double(route.length), unit: UnitLength.meters)
+        return MeasurementFormatter.currentLongUnitFormatter.string(from: distance)
+    }
+
     /// The route object which provides the main data.
     private let route: NMARoute
 

--- a/MSDKUI_Tests/GuidanceNextManeuverViewTests.swift
+++ b/MSDKUI_Tests/GuidanceNextManeuverViewTests.swift
@@ -160,6 +160,21 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
         XCTAssertEqual(nextManeuverView.accessibilityHint, exepectedHint, "It returns the correct hint")
     }
 
+    /// Tests if the view's distance label's accessibility label is correct when model is populated
+    /// with the default distance formatter.
+    func testViewDistanceLabelAccessibilityLabelWithDefaultDistanceFormatter() {
+        let distance = Measurement<UnitLength>(value: 100, unit: .meters)
+        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(),
+                                                           distance: distance,
+                                                           streetName: "Invalidenstr.")
+
+        nextManeuverView.configure(with: viewModel)
+
+        let exepectedLabel = MeasurementFormatter.currentLongUnitFormatter.string(from: distance)
+
+        XCTAssertEqual(nextManeuverView.distanceLabel.accessibilityLabel, exepectedLabel, "It returns the correct label")
+    }
+
     /// Tests if the view accessibility hint is correct when model is populated with a custom distance formatter.
     func testViewAccessibilityHintWithCustomDistanceFormatter() {
         let distance = Measurement<UnitLength>(value: 100, unit: .meters)
@@ -175,6 +190,23 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
             + (viewModel.streetName ?? "")
 
         XCTAssertEqual(nextManeuverView.accessibilityHint, exepectedHint, "It returns the correct hint")
+    }
+
+    /// Tests if the view's distance label's accessibility label is correct when model is populated
+    /// with a custom accessibility distance formatter.
+    func testViewDistanceLabelAccessibilityLabelWithCustomDistanceFormatter() {
+        let distance = Measurement<UnitLength>(value: 100, unit: .meters)
+        let distanceFormatter = MeasurementFormatter()
+        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(),
+                                                           distance: distance,
+                                                           streetName: "Invalidenstr.",
+                                                           accessibilityDistanceFormatter: distanceFormatter)
+
+        nextManeuverView.configure(with: viewModel)
+
+        let exepectedLabel = distanceFormatter.string(from: distance)
+
+        XCTAssertEqual(nextManeuverView.distanceLabel.accessibilityLabel, exepectedLabel, "It returns the correct label")
     }
 
     /// Tests if the view accessibility hint is correct when model is populated with an incomplete model.

--- a/MSDKUI_Tests/ManeuverItemViewTests.swift
+++ b/MSDKUI_Tests/ManeuverItemViewTests.swift
@@ -87,11 +87,13 @@ final class ManeuverItemViewTests: XCTestCase {
         let item = try require(itemView)
         let expectedDistance = Measurement(value: 200, unit: UnitLength.meters)
         let expectedFormattedDistance = MeasurementFormatter.currentMediumUnitFormatter.string(from: expectedDistance)
+        let expectedLongFormattedDistance = MeasurementFormatter.currentLongUnitFormatter.string(from: expectedDistance)
 
         XCTAssertLocalized(item.instructionLabel.text, key: "msdkui_maneuver_enter_highway", bundle: .MSDKUI,
                            "item is displaying wrong instruction")
 
         XCTAssertEqual(item.distanceLabel.text, expectedFormattedDistance, "Maneuver should display distance 200 m")
+        XCTAssertEqual(item.distanceLabel.accessibilityLabel, expectedLongFormattedDistance, "Maneuver should read distance 200 meters")
     }
 
     /// Tests `String` to `Section` and `Section` to `String` conversion.


### PR DESCRIPTION
- adds long distance string formatting for use with accessibility labels
- adds long format length for route description item handler for use with accessibility labels

Signed-off-by: Piotr Marczycki <piotrekm44@users.noreply.github.com>