### PR TITLE
MSDKUI-1766: Align GuidanceNextManeuverView background size with content

### DIFF
--- a/MSDKUI/Assets/GuidanceNextManeuverView.xib
+++ b/MSDKUI/Assets/GuidanceNextManeuverView.xib
@@ -12,8 +12,8 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="GuidanceNextManeuverView" customModule="MSDKUI" customModuleProvider="target">
             <connections>
                 <outlet property="distanceLabel" destination="sCU-qM-EZl" id="yY3-K1-Hr1"/>
+                <outlet property="maneuverImageHeightConstraint" destination="oLv-fc-4QF" id="l4C-Lo-WAB"/>
                 <outlet property="maneuverImageView" destination="p0e-Lb-zDt" id="hXK-iT-eFc"/>
-                <outlet property="maneuverImageViewContainer" destination="TUk-YB-RZY" id="Hwe-d0-9Cp"/>
                 <outlet property="separatorLabel" destination="Al9-lS-4w7" id="wib-7r-khE"/>
                 <outlet property="streetNameLabel" destination="1fM-b3-8Pq" id="2Oi-8G-jCV"/>
             </connections>
@@ -26,23 +26,18 @@
                 <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="R9j-N6-b1B">
                     <rect key="frame" x="16" y="8" width="343" height="32"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TUk-YB-RZY">
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="p0e-Lb-zDt">
                             <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
-                            <subviews>
-                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="p0e-Lb-zDt">
-                                    <rect key="frame" x="0.0" y="4" width="24" height="24"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="24" id="bSd-Rz-QSl"/>
-                                        <constraint firstAttribute="height" constant="24" id="xXK-4p-ImB"/>
-                                    </constraints>
-                                </imageView>
-                            </subviews>
                             <constraints>
-                                <constraint firstItem="p0e-Lb-zDt" firstAttribute="leading" secondItem="TUk-YB-RZY" secondAttribute="leading" id="1yZ-jF-dqh"/>
-                                <constraint firstItem="p0e-Lb-zDt" firstAttribute="centerY" secondItem="TUk-YB-RZY" secondAttribute="centerY" id="gfJ-Zw-8ur"/>
-                                <constraint firstAttribute="width" constant="32" id="psh-eL-pe8"/>
+                                <constraint firstAttribute="height" constant="32" id="oLv-fc-4QF"/>
+                                <constraint firstAttribute="width" secondItem="p0e-Lb-zDt" secondAttribute="height" multiplier="1:1" id="tSZ-bf-NL7"/>
                             </constraints>
-                        </view>
+                            <variation key="default">
+                                <mask key="constraints">
+                                    <exclude reference="oLv-fc-4QF"/>
+                                </mask>
+                            </variation>
+                        </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Distance" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sCU-qM-EZl">
                             <rect key="frame" x="40" y="6" width="67" height="20.5"/>
                             <accessibility key="accessibilityConfiguration">

--- a/MSDKUI/Classes/GuidanceNextManeuverView.swift
+++ b/MSDKUI/Classes/GuidanceNextManeuverView.swift
@@ -60,11 +60,12 @@ import UIKit
 
     // MARK: - Properties
 
-    /// Container view of the next maneuver icon.
-    @IBOutlet private(set) var maneuverImageViewContainer: UIView!
-
     /// Image view for the icon of the next manuever.
     @IBOutlet private(set) var maneuverImageView: UIImageView!
+
+    /// Height constraint of the next maneuver icon image.
+    /// By default the constraint is not active.
+    @IBOutlet private(set) var maneuverImageHeightConstraint: NSLayoutConstraint!
 
     /// Label for the travel distance of the next manuever.
     @IBOutlet private(set) var distanceLabel: UILabel!
@@ -119,11 +120,13 @@ import UIKit
 
         // When icon is nil, it should be removed (not visible, giving space to the rest of the views)
         if let icon = model.maneuverIcon {
-            maneuverImageViewContainer.isHidden = false
+            maneuverImageView.isHidden = false
             maneuverImageView.image = icon
+            maneuverImageHeightConstraint.isActive = true
         } else {
-            maneuverImageViewContainer.isHidden = true
+            maneuverImageHeightConstraint.isActive = false
             maneuverImageView.image = nil
+            maneuverImageView.isHidden = true
         }
 
         // When ViewModel.streetName is nil, the dot & street name label's should be hidden

--- a/MSDKUI_Tests/GuidanceNextManeuverViewTests.swift
+++ b/MSDKUI_Tests/GuidanceNextManeuverViewTests.swift
@@ -71,8 +71,9 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
 
         nextManeuverView.configure(with: viewModel)
 
-        XCTAssertFalse(nextManeuverView.maneuverImageViewContainer.isHidden, "The container of maneuver icon is visible")
         XCTAssertFalse(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is visible")
+        XCTAssertNotNil(nextManeuverView.maneuverImageView.image, "The maneuver icon is set")
+        XCTAssertTrue(nextManeuverView.maneuverImageHeightConstraint.isActive, "The maneuver icon height constraint is active")
         XCTAssertFalse(nextManeuverView.distanceLabel.isHidden, "The distance label is visible")
         XCTAssertFalse(nextManeuverView.separatorLabel.isHidden, "The separator label is visible")
         XCTAssertFalse(nextManeuverView.streetNameLabel.isHidden, "The street name label is visible")
@@ -87,7 +88,9 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
 
         nextManeuverView.configure(with: viewModel)
 
-        XCTAssertFalse(nextManeuverView.maneuverImageViewContainer.isHidden, "The container of maneuver icon is visible")
+        XCTAssertFalse(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is visible")
+        XCTAssertNotNil(nextManeuverView.maneuverImageView.image, "The maneuver icon is set")
+        XCTAssertTrue(nextManeuverView.maneuverImageHeightConstraint.isActive, "The maneuver icon height constraint is active")
         XCTAssertFalse(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is visible")
         XCTAssertFalse(nextManeuverView.distanceLabel.isHidden, "The distance label is visible")
         XCTAssertTrue(nextManeuverView.separatorLabel.isHidden, "The separator label is hidden")
@@ -103,8 +106,9 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
 
         nextManeuverView.configure(with: viewModel)
 
-        XCTAssertTrue(nextManeuverView.maneuverImageViewContainer.isHidden, "The container of maneuver icon is hidden")
-        XCTAssertFalse(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is visible")
+        XCTAssertTrue(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is hidden")
+        XCTAssertNil(nextManeuverView.maneuverImageView.image, "The maneuver icon is not set")
+        XCTAssertFalse(nextManeuverView.maneuverImageHeightConstraint.isActive, "The maneuver icon height constraint is inactive")
         XCTAssertFalse(nextManeuverView.distanceLabel.isHidden, "The distance label is visible")
         XCTAssertFalse(nextManeuverView.separatorLabel.isHidden, "The separator label is visible")
         XCTAssertFalse(nextManeuverView.streetNameLabel.isHidden, "The street name label is visible")


### PR DESCRIPTION
- changes the view hierarchy by removing container view
  of maneuver image view
- changes the maneuver image view height constraint handling
  to work with stack view's automatic height constraint application
  when the arranged subview is hidden
- adds a width equal to its height constraint for maneuver image view
  to react to different height constraints
- updates unit tests for the new maneuver image view handling

Signed-off-by: Piotr Marczycki <piotrekm44@users.noreply.github.com>