### PR TITLE
MSDKUI-1782: Update copyright headers

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -225,7 +225,7 @@ private_outlet:
 file_header:
   required_pattern: |
                     \/\/
-                    \/\/ Copyright \(C\) 2017-\d{4} HERE Europe B\.V\.
+                    \/\/ Copyright \(C\) 2017-2019 HERE Europe B\.V\.
                     \/\/
                     \/\/ Licensed under the Apache License, Version 2\.0 \(the "License"\);
                     \/\/ you may not use this file except in compliance with the License\.

--- a/Commons_Tests/Extensions/ExtensionUIAlertController.swift
+++ b/Commons_Tests/Extensions/ExtensionUIAlertController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Extensions/ExtensionUIBarButtonItem.swift
+++ b/Commons_Tests/Extensions/ExtensionUIBarButtonItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Extensions/ExtensionUIStoryboard.swift
+++ b/Commons_Tests/Extensions/ExtensionUIStoryboard.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Extensions/ExtensionUITableView.swift
+++ b/Commons_Tests/Extensions/ExtensionUITableView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Extensions/ExtensionXCTestCase.swift
+++ b/Commons_Tests/Extensions/ExtensionXCTestCase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Fixtures/NMAGeoCoordinatesFixture.swift
+++ b/Commons_Tests/Fixtures/NMAGeoCoordinatesFixture.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Fixtures/NMAGeoPositionFixture.swift
+++ b/Commons_Tests/Fixtures/NMAGeoPositionFixture.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Fixtures/NMAImageFixture.swift
+++ b/Commons_Tests/Fixtures/NMAImageFixture.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Fixtures/WaypointEntryFixture.swift
+++ b/Commons_Tests/Fixtures/WaypointEntryFixture.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/CurrentPositionProviderMock.swift
+++ b/Commons_Tests/Mocks/CurrentPositionProviderMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/EstimatedArrivalProviderMock.swift
+++ b/Commons_Tests/Mocks/EstimatedArrivalProviderMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/GuidanceEstimatedArrivalMonitorDelegateMock.swift
+++ b/Commons_Tests/Mocks/GuidanceEstimatedArrivalMonitorDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/GuidanceManeuverMonitorDelegateMock.swift
+++ b/Commons_Tests/Mocks/GuidanceManeuverMonitorDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/GuidanceNextManeuverMonitorDelegateMock.swift
+++ b/Commons_Tests/Mocks/GuidanceNextManeuverMonitorDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/GuidanceSpeedMonitorDelegateMock.swift
+++ b/Commons_Tests/Mocks/GuidanceSpeedMonitorDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/MockUtils.h
+++ b/Commons_Tests/Mocks/MockUtils.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/MockUtils.m
+++ b/Commons_Tests/Mocks/MockUtils.m
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/NMAMapViewPartialMock.swift
+++ b/Commons_Tests/Mocks/NMAMapViewPartialMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/NMANavigationManagerDelegateMock.swift
+++ b/Commons_Tests/Mocks/NMANavigationManagerDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/NavigationManagerDelegateDispatcherMock.swift
+++ b/Commons_Tests/Mocks/NavigationManagerDelegateDispatcherMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/NotificationCenterObservingMock.swift
+++ b/Commons_Tests/Mocks/NotificationCenterObservingMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/OptionItemDelegateMock.swift
+++ b/Commons_Tests/Mocks/OptionItemDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/OptionsPanelDelegateMock.swift
+++ b/Commons_Tests/Mocks/OptionsPanelDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/RouteDescriptionListDelegateMock.swift
+++ b/Commons_Tests/Mocks/RouteDescriptionListDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/TransportModePanelDelegateMock.swift
+++ b/Commons_Tests/Mocks/TransportModePanelDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/TravelTimePanelDelegateMock.swift
+++ b/Commons_Tests/Mocks/TravelTimePanelDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Commons_Tests/Mocks/TravelTimePickerDelegateMock.swift
+++ b/Commons_Tests/Mocks/TravelTimePickerDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Documentation/Guides_Examples/HelloMSDKUI/HelloMSDKUI/AppDelegate.swift
+++ b/Documentation/Guides_Examples/HelloMSDKUI/HelloMSDKUI/AppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Documentation/Guides_Examples/HelloMSDKUI/HelloMSDKUI/ViewController.swift
+++ b/Documentation/Guides_Examples/HelloMSDKUI/HelloMSDKUI/ViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Documentation/Guides_Examples/MSDKUIPrimer/MSDKUIPrimer/AppDelegate.swift
+++ b/Documentation/Guides_Examples/MSDKUIPrimer/MSDKUIPrimer/AppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Documentation/Guides_Examples/MSDKUIPrimer/MSDKUIPrimer/GuidanceHelper.swift
+++ b/Documentation/Guides_Examples/MSDKUIPrimer/MSDKUIPrimer/GuidanceHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Documentation/Guides_Examples/MSDKUIPrimer/MSDKUIPrimer/GuidanceViewController.swift
+++ b/Documentation/Guides_Examples/MSDKUIPrimer/MSDKUIPrimer/GuidanceViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Documentation/Guides_Examples/MSDKUIPrimer/MSDKUIPrimer/ManeuverViewController.swift
+++ b/Documentation/Guides_Examples/MSDKUIPrimer/MSDKUIPrimer/ManeuverViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Documentation/Guides_Examples/MSDKUIPrimer/MSDKUIPrimer/RouteHelper.swift
+++ b/Documentation/Guides_Examples/MSDKUIPrimer/MSDKUIPrimer/RouteHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Documentation/Guides_Examples/MSDKUIPrimer/MSDKUIPrimer/ViewController.swift
+++ b/Documentation/Guides_Examples/MSDKUIPrimer/MSDKUIPrimer/ViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/BooleanOptionItem.swift
+++ b/MSDKUI/Classes/BooleanOptionItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionArray.swift
+++ b/MSDKUI/Classes/ExtensionArray.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionBundle.swift
+++ b/MSDKUI/Classes/ExtensionBundle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionDate.swift
+++ b/MSDKUI/Classes/ExtensionDate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionDateFormatter.swift
+++ b/MSDKUI/Classes/ExtensionDateFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionLocale.swift
+++ b/MSDKUI/Classes/ExtensionLocale.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionMeasurementFormatter.swift
+++ b/MSDKUI/Classes/ExtensionMeasurementFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionNMAManeuver.swift
+++ b/MSDKUI/Classes/ExtensionNMAManeuver.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionNMANavigationManager.swift
+++ b/MSDKUI/Classes/ExtensionNMANavigationManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionNMAPositioningManager.swift
+++ b/MSDKUI/Classes/ExtensionNMAPositioningManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionNMARoute.swift
+++ b/MSDKUI/Classes/ExtensionNMARoute.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionNotificationCenter.swift
+++ b/MSDKUI/Classes/ExtensionNotificationCenter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionNumberFormatter.swift
+++ b/MSDKUI/Classes/ExtensionNumberFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionOptional.swift
+++ b/MSDKUI/Classes/ExtensionOptional.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionString.swift
+++ b/MSDKUI/Classes/ExtensionString.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionTimeInterval.swift
+++ b/MSDKUI/Classes/ExtensionTimeInterval.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionUIImage.swift
+++ b/MSDKUI/Classes/ExtensionUIImage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionUIResponder.swift
+++ b/MSDKUI/Classes/ExtensionUIResponder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ExtensionUIView.swift
+++ b/MSDKUI/Classes/ExtensionUIView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/GuidanceCurrentStreetNameMonitor.swift
+++ b/MSDKUI/Classes/GuidanceCurrentStreetNameMonitor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/GuidanceEstimatedArrivalMonitor.swift
+++ b/MSDKUI/Classes/GuidanceEstimatedArrivalMonitor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/GuidanceEstimatedArrivalView.swift
+++ b/MSDKUI/Classes/GuidanceEstimatedArrivalView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/GuidanceManeuverData.swift
+++ b/MSDKUI/Classes/GuidanceManeuverData.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/GuidanceManeuverMonitor.swift
+++ b/MSDKUI/Classes/GuidanceManeuverMonitor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/GuidanceManeuverUtil.swift
+++ b/MSDKUI/Classes/GuidanceManeuverUtil.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/GuidanceManeuverView.swift
+++ b/MSDKUI/Classes/GuidanceManeuverView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/GuidanceNextManeuverMonitor.swift
+++ b/MSDKUI/Classes/GuidanceNextManeuverMonitor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/GuidanceNextManeuverView.swift
+++ b/MSDKUI/Classes/GuidanceNextManeuverView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/GuidanceSpeedLimitView.swift
+++ b/MSDKUI/Classes/GuidanceSpeedLimitView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/GuidanceSpeedMonitor.swift
+++ b/MSDKUI/Classes/GuidanceSpeedMonitor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/GuidanceSpeedView.swift
+++ b/MSDKUI/Classes/GuidanceSpeedView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/GuidanceStreetLabel.swift
+++ b/MSDKUI/Classes/GuidanceStreetLabel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/HazardousMaterialsOptionsPanel.swift
+++ b/MSDKUI/Classes/HazardousMaterialsOptionsPanel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ManeuverItemView.swift
+++ b/MSDKUI/Classes/ManeuverItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ManeuverResources.swift
+++ b/MSDKUI/Classes/ManeuverResources.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/ManeuverTableView.swift
+++ b/MSDKUI/Classes/ManeuverTableView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/MulticastDelegate.swift
+++ b/MSDKUI/Classes/MulticastDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/MultipleChoiceOptionItem.swift
+++ b/MSDKUI/Classes/MultipleChoiceOptionItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/NavigationManagerDelegateDispatcher.swift
+++ b/MSDKUI/Classes/NavigationManagerDelegateDispatcher.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/NumericOptionItem.swift
+++ b/MSDKUI/Classes/NumericOptionItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/OptionItem.swift
+++ b/MSDKUI/Classes/OptionItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/OptionItemSpec.swift
+++ b/MSDKUI/Classes/OptionItemSpec.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/OptionsPanel.swift
+++ b/MSDKUI/Classes/OptionsPanel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/RouteBarScaler.swift
+++ b/MSDKUI/Classes/RouteBarScaler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/RouteDescriptionItem.swift
+++ b/MSDKUI/Classes/RouteDescriptionItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/RouteDescriptionItemHandler.swift
+++ b/MSDKUI/Classes/RouteDescriptionItemHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/RouteDescriptionList.swift
+++ b/MSDKUI/Classes/RouteDescriptionList.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/RouteTypeOptionsPanel.swift
+++ b/MSDKUI/Classes/RouteTypeOptionsPanel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/RoutingOptionsPanel.swift
+++ b/MSDKUI/Classes/RoutingOptionsPanel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/SingleChoiceOptionItem.swift
+++ b/MSDKUI/Classes/SingleChoiceOptionItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/Style.swift
+++ b/MSDKUI/Classes/Style.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/Styles.swift
+++ b/MSDKUI/Classes/Styles.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/TitleItem.swift
+++ b/MSDKUI/Classes/TitleItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/TrafficOptionsPanel.swift
+++ b/MSDKUI/Classes/TrafficOptionsPanel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/TransportModePanel.swift
+++ b/MSDKUI/Classes/TransportModePanel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/TravelTimePanel.swift
+++ b/MSDKUI/Classes/TravelTimePanel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/TravelTimePicker.swift
+++ b/MSDKUI/Classes/TravelTimePicker.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/TruckOptionsPanel.swift
+++ b/MSDKUI/Classes/TruckOptionsPanel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/TunnelOptionsPanel.swift
+++ b/MSDKUI/Classes/TunnelOptionsPanel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/Version.swift
+++ b/MSDKUI/Classes/Version.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/WaypointEntry.swift
+++ b/MSDKUI/Classes/WaypointEntry.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/WaypointItem.swift
+++ b/MSDKUI/Classes/WaypointItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI/Classes/WaypointList.swift
+++ b/MSDKUI/Classes/WaypointList.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/AboutTableViewCell.swift
+++ b/MSDKUI_Demo/AboutTableViewCell.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/AboutTableViewDataSource.swift
+++ b/MSDKUI_Demo/AboutTableViewDataSource.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/AboutViewController.swift
+++ b/MSDKUI_Demo/AboutViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/AppDelegate.swift
+++ b/MSDKUI_Demo/AppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/EmptyView.swift
+++ b/MSDKUI_Demo/EmptyView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/ExtensionArray.swift
+++ b/MSDKUI_Demo/ExtensionArray.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/ExtensionBundle.swift
+++ b/MSDKUI_Demo/ExtensionBundle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/ExtensionNMACoreRouter.swift
+++ b/MSDKUI_Demo/ExtensionNMACoreRouter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/ExtensionNMAGeocoder.swift
+++ b/MSDKUI_Demo/ExtensionNMAGeocoder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/ExtensionNMAMapMarker.swift
+++ b/MSDKUI_Demo/ExtensionNMAMapMarker.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/ExtensionNMAMapView.swift
+++ b/MSDKUI_Demo/ExtensionNMAMapView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/ExtensionNMARoutingError.swift
+++ b/MSDKUI_Demo/ExtensionNMARoutingError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/ExtensionString.swift
+++ b/MSDKUI_Demo/ExtensionString.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/ExtensionUIApplication.swift
+++ b/MSDKUI_Demo/ExtensionUIApplication.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/ExtensionUITableViewCell.swift
+++ b/MSDKUI_Demo/ExtensionUITableViewCell.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/GuidanceDashboardTableViewCell.swift
+++ b/MSDKUI_Demo/GuidanceDashboardTableViewCell.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/GuidanceDashboardTableViewDataSource.swift
+++ b/MSDKUI_Demo/GuidanceDashboardTableViewDataSource.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/GuidanceDashboardViewController.swift
+++ b/MSDKUI_Demo/GuidanceDashboardViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/GuidancePresentingViewController.swift
+++ b/MSDKUI_Demo/GuidancePresentingViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/GuidanceViewController.swift
+++ b/MSDKUI_Demo/GuidanceViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/IconButton.swift
+++ b/MSDKUI_Demo/IconButton.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/LandingViewController.swift
+++ b/MSDKUI_Demo/LandingViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/LocationBasedViewController.swift
+++ b/MSDKUI_Demo/LocationBasedViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/ManeuversOverviewViewController.swift
+++ b/MSDKUI_Demo/ManeuversOverviewViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/MapRouteHandler.swift
+++ b/MSDKUI_Demo/MapRouteHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/MapViewportHandler.swift
+++ b/MSDKUI_Demo/MapViewportHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/OptionPanelViewController.swift
+++ b/MSDKUI_Demo/OptionPanelViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/OptionsViewController.swift
+++ b/MSDKUI_Demo/OptionsViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/RouteOverviewViewController.swift
+++ b/MSDKUI_Demo/RouteOverviewViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/RouteViewController.swift
+++ b/MSDKUI_Demo/RouteViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/ViewController.swift
+++ b/MSDKUI_Demo/ViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo/WaypointViewController.swift
+++ b/MSDKUI_Demo/WaypointViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Extensions/ExtensionArrayTests.swift
+++ b/MSDKUI_Demo_Tests/Extensions/ExtensionArrayTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Extensions/ExtensionNMALayoutPosition.swift
+++ b/MSDKUI_Demo_Tests/Extensions/ExtensionNMALayoutPosition.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Extensions/ExtensionNMAMapViewTests.swift
+++ b/MSDKUI_Demo_Tests/Extensions/ExtensionNMAMapViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Extensions/ExtensionNMARoutingErrorTests.swift
+++ b/MSDKUI_Demo_Tests/Extensions/ExtensionNMARoutingErrorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Extensions/ExtensionUITableViewCellTests.swift
+++ b/MSDKUI_Demo_Tests/Extensions/ExtensionUITableViewCellTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Fixtures/UIImageFixture.swift
+++ b/MSDKUI_Demo_Tests/Fixtures/UIImageFixture.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Handlers/MapViewportHandlerTests.swift
+++ b/MSDKUI_Demo_Tests/Handlers/MapViewportHandlerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Mocks/GuidanceDashboardViewControllerDelegateMock.swift
+++ b/MSDKUI_Demo_Tests/Mocks/GuidanceDashboardViewControllerDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Mocks/IdleTimerDisablerMock.swift
+++ b/MSDKUI_Demo_Tests/Mocks/IdleTimerDisablerMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Mocks/MSDKUI_Demo-Bridging-Header.h
+++ b/MSDKUI_Demo_Tests/Mocks/MSDKUI_Demo-Bridging-Header.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Mocks/MapRouteHandlerMock.swift
+++ b/MSDKUI_Demo_Tests/Mocks/MapRouteHandlerMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Mocks/MapViewportHandlerMock.swift
+++ b/MSDKUI_Demo_Tests/Mocks/MapViewportHandlerMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Mocks/NMACoreRouterMock.swift
+++ b/MSDKUI_Demo_Tests/Mocks/NMACoreRouterMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Mocks/NMAGeocoderMock.swift
+++ b/MSDKUI_Demo_Tests/Mocks/NMAGeocoderMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Mocks/OptionsDelegateMock.swift
+++ b/MSDKUI_Demo_Tests/Mocks/OptionsDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Mocks/URLOpenerMock.swift
+++ b/MSDKUI_Demo_Tests/Mocks/URLOpenerMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/AboutTableViewDataSourceTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/AboutTableViewDataSourceTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/AboutViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/AboutViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/GuidanceDashboardTableViewDataSourceTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/GuidanceDashboardTableViewDataSourceTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/GuidanceDashboardViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/GuidanceDashboardViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/GuidancePresentingViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/GuidancePresentingViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/GuidanceViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/GuidanceViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/LandingViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/LandingViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/LocationBasedViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/LocationBasedViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/ManeuversOverviewViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/ManeuversOverviewViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/OptionPanelViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/OptionPanelViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/OptionsViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/OptionsViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/RouteOverviewViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/RouteOverviewViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/RouteViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/RouteViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/ViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/ViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/View Controllers/WaypointViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/WaypointViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Views/AboutTableViewCellTests.swift
+++ b/MSDKUI_Demo_Tests/Views/AboutTableViewCellTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Views/EmptyViewTests.swift
+++ b/MSDKUI_Demo_Tests/Views/EmptyViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Views/GuidanceDashboardTableViewCellTests.swift
+++ b/MSDKUI_Demo_Tests/Views/GuidanceDashboardTableViewCellTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_Tests/Views/IconButtonTests.swift
+++ b/MSDKUI_Demo_Tests/Views/IconButtonTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Core/CoreActions.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Core/CoreActions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Core/CoreMatchers.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Core/CoreMatchers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Utils/Constants.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Utils/Constants.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Utils/PositionDataSource.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Utils/PositionDataSource.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Utils/Positioning.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Utils/Positioning.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Utils/TestData/TestStrings.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Utils/TestData/TestStrings.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Utils/Utils.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Utils/Utils.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Views/DriveNavigation/DriveNavigationActions.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Views/DriveNavigation/DriveNavigationActions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Views/DriveNavigation/DriveNavigationMatchers.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Views/DriveNavigation/DriveNavigationMatchers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Views/Landing/LandingActions.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Views/Landing/LandingActions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Views/Landing/LandingMatchers.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Views/Landing/LandingMatchers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Views/RouteOverView/RouteOverViewActions.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Views/RouteOverView/RouteOverViewActions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Views/RouteOverView/RouteOverViewMatchers.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Views/RouteOverView/RouteOverViewMatchers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Views/RoutePlanner/RoutePlannerActions.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Views/RoutePlanner/RoutePlannerActions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Views/RoutePlanner/RoutePlannerMatchers.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Views/RoutePlanner/RoutePlannerMatchers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Views/RoutePlanner/RoutePlannerOptionsMatchers.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Views/RoutePlanner/RoutePlannerOptionsMatchers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Views/Waypoints/WaypointActions.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Views/Waypoints/WaypointActions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Impl/Views/Waypoints/WaypointMatchers.swift
+++ b/MSDKUI_Demo_UI_Tests/Impl/Views/Waypoints/WaypointMatchers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Tests/DriveNavigation/Functional/GuidanceAndManeuversTests.swift
+++ b/MSDKUI_Demo_UI_Tests/Tests/DriveNavigation/Functional/GuidanceAndManeuversTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Tests/DriveNavigation/Integration/GuidanceIntegrationTests.swift
+++ b/MSDKUI_Demo_UI_Tests/Tests/DriveNavigation/Integration/GuidanceIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Tests/RoutePlanner/Functional/RoutesAndManeuversTests.swift
+++ b/MSDKUI_Demo_UI_Tests/Tests/RoutePlanner/Functional/RoutesAndManeuversTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Tests/RoutePlanner/Functional/WaypointListTests.swift
+++ b/MSDKUI_Demo_UI_Tests/Tests/RoutePlanner/Functional/WaypointListTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Tests/RoutePlanner/Integration/RouteOptionsIntegrationTests.swift
+++ b/MSDKUI_Demo_UI_Tests/Tests/RoutePlanner/Integration/RouteOptionsIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Demo_UI_Tests/Tests/RoutePlanner/Integration/RoutePlannerIntegrationTests.swift
+++ b/MSDKUI_Demo_UI_Tests/Tests/RoutePlanner/Integration/RoutePlannerIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/AppDelegate.swift
+++ b/MSDKUI_Dev/AppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/GuidanceEstimatedArrivalSettingsViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceEstimatedArrivalSettingsViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/GuidanceEstimatedArrivalViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceEstimatedArrivalViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/GuidanceManeuverSettingsViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceManeuverSettingsViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/GuidanceManeuverViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceManeuverViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/GuidanceNextManeuverSettingsViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceNextManeuverSettingsViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/GuidanceNextManeuverViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceNextManeuverViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/GuidanceSpeedLimitSettingsViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceSpeedLimitSettingsViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/GuidanceSpeedLimitViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceSpeedLimitViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/GuidanceSpeedSettingsViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceSpeedSettingsViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/GuidanceSpeedViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceSpeedViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/GuidanceStreetSettingsViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceStreetSettingsViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/GuidanceStreetViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceStreetViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/ManeuverItemSettingsViewController.swift
+++ b/MSDKUI_Dev/Components/ManeuverItemSettingsViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Components/ManeuverItemViewController.swift
+++ b/MSDKUI_Dev/Components/ManeuverItemViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/ComponentsCell.swift
+++ b/MSDKUI_Dev/ComponentsCell.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/ComponentsDataSource.swift
+++ b/MSDKUI_Dev/ComponentsDataSource.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/ComponentsViewController.swift
+++ b/MSDKUI_Dev/ComponentsViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Extensions/ExtensionUITableView.swift
+++ b/MSDKUI_Dev/Extensions/ExtensionUITableView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/Extensions/ExtensionUITableViewCell.swift
+++ b/MSDKUI_Dev/Extensions/ExtensionUITableViewCell.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Dev/SettingsViewController.swift
+++ b/MSDKUI_Dev/SettingsViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/BooleanOptionItemTests.swift
+++ b/MSDKUI_Tests/BooleanOptionItemTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/ExtensionArrayTests.swift
+++ b/MSDKUI_Tests/ExtensionArrayTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/ExtensionDateFormatterTests.swift
+++ b/MSDKUI_Tests/ExtensionDateFormatterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/ExtensionLocaleTests.swift
+++ b/MSDKUI_Tests/ExtensionLocaleTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/ExtensionMeasurementFormatterTests.swift
+++ b/MSDKUI_Tests/ExtensionMeasurementFormatterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/ExtensionNumberFormatterTests.swift
+++ b/MSDKUI_Tests/ExtensionNumberFormatterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceCurrentStreetNameMonitorDelegateMock.swift
+++ b/MSDKUI_Tests/GuidanceCurrentStreetNameMonitorDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceCurrentStreetNameMonitorTests.swift
+++ b/MSDKUI_Tests/GuidanceCurrentStreetNameMonitorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceEstimatedArrivalMonitorTests.swift
+++ b/MSDKUI_Tests/GuidanceEstimatedArrivalMonitorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceEstimatedArrivalViewTests.swift
+++ b/MSDKUI_Tests/GuidanceEstimatedArrivalViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceManeuverDataTests.swift
+++ b/MSDKUI_Tests/GuidanceManeuverDataTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceManeuverMonitorTests.swift
+++ b/MSDKUI_Tests/GuidanceManeuverMonitorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceManeuverUtilTests.swift
+++ b/MSDKUI_Tests/GuidanceManeuverUtilTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceManeuverViewTests.swift
+++ b/MSDKUI_Tests/GuidanceManeuverViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceNextManeuverMonitorTests.swift
+++ b/MSDKUI_Tests/GuidanceNextManeuverMonitorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceNextManeuverViewTests.swift
+++ b/MSDKUI_Tests/GuidanceNextManeuverViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceSpeedLimitViewTests.swift
+++ b/MSDKUI_Tests/GuidanceSpeedLimitViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceSpeedMonitorTests.swift
+++ b/MSDKUI_Tests/GuidanceSpeedMonitorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceSpeedViewTests.swift
+++ b/MSDKUI_Tests/GuidanceSpeedViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/GuidanceStreetLabelTests.swift
+++ b/MSDKUI_Tests/GuidanceStreetLabelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/HazardousMaterialsOptionsPanelTests.swift
+++ b/MSDKUI_Tests/HazardousMaterialsOptionsPanelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/MSDKUI_Tests-Bridging-Header.h
+++ b/MSDKUI_Tests/MSDKUI_Tests-Bridging-Header.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/ManeuverItemViewTests.swift
+++ b/MSDKUI_Tests/ManeuverItemViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/ManeuverResourcesTest.swift
+++ b/MSDKUI_Tests/ManeuverResourcesTest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/ManeuverTableViewTests.swift
+++ b/MSDKUI_Tests/ManeuverTableViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/MulticastDelegateTests.swift
+++ b/MSDKUI_Tests/MulticastDelegateTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/MultipleChoiceOptionItemTests.swift
+++ b/MSDKUI_Tests/MultipleChoiceOptionItemTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/NavigationManagerDelegateDispatcherTests.swift
+++ b/MSDKUI_Tests/NavigationManagerDelegateDispatcherTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/NumericOptionItemTests.swift
+++ b/MSDKUI_Tests/NumericOptionItemTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/RouteDescriptionItemTests.swift
+++ b/MSDKUI_Tests/RouteDescriptionItemTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/RouteDescriptionListTests.swift
+++ b/MSDKUI_Tests/RouteDescriptionListTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/RouteTypeOptionsPanelTests.swift
+++ b/MSDKUI_Tests/RouteTypeOptionsPanelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/RoutingOptionsPanelTests.swift
+++ b/MSDKUI_Tests/RoutingOptionsPanelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/SingleChoiceOptionItemTests.swift
+++ b/MSDKUI_Tests/SingleChoiceOptionItemTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/TitleItemTests.swift
+++ b/MSDKUI_Tests/TitleItemTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/TrafficOptionsPanelTests.swift
+++ b/MSDKUI_Tests/TrafficOptionsPanelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/TransportModePanelTests.swift
+++ b/MSDKUI_Tests/TransportModePanelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/TravelTimePanelTests.swift
+++ b/MSDKUI_Tests/TravelTimePanelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/TravelTimePickerTests.swift
+++ b/MSDKUI_Tests/TravelTimePickerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/TruckOptionsPanelTests.swift
+++ b/MSDKUI_Tests/TruckOptionsPanelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/TunnelOptionsPanelTests.swift
+++ b/MSDKUI_Tests/TunnelOptionsPanelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/Utils.swift
+++ b/MSDKUI_Tests/Utils.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/VersionTests.swift
+++ b/MSDKUI_Tests/VersionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/WaypointEntryTests.swift
+++ b/MSDKUI_Tests/WaypointEntryTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/WaypointItemTests.swift
+++ b/MSDKUI_Tests/WaypointItemTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MSDKUI_Tests/WaypointListTests.swift
+++ b/MSDKUI_Tests/WaypointListTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2017-2018 HERE Europe B.V.
+// Copyright (C) 2017-2019 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ Please have a look at our [Quick Start](https://github.com/heremaps/msdkui-ios/b
 We are happy to hear your feedback. Please [contact us](https://developer.here.com/contact-us) for any questions, suggestions or improvements. Thank you for your using the HERE Mobile SDK UI Kit.
 
 ## License
-Copyright (c) 2017-2018 HERE Europe B.V.
+Copyright (C) 2017-2019 HERE Europe B.V.
 
 See the [LICENSE](https://github.com/heremaps/msdkui-ios/blob/master/LICENSE) file in the root of this project for license details.

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2018 HERE Europe B.V.
+# Copyright (C) 2017-2019 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR updates all the copyright headers and changes the SwiftLint rule to require 2019 as "end date" (rather than using a regular expression to match 4 digits).