### PR TITLE
MSDKUI-1766: Fix maneuver image size after rotation

### DIFF
--- a/MSDKUI/Assets/GuidanceNextManeuverView.xib
+++ b/MSDKUI/Assets/GuidanceNextManeuverView.xib
@@ -32,11 +32,6 @@
                                 <constraint firstAttribute="height" constant="32" id="oLv-fc-4QF"/>
                                 <constraint firstAttribute="width" secondItem="p0e-Lb-zDt" secondAttribute="height" multiplier="1:1" id="tSZ-bf-NL7"/>
                             </constraints>
-                            <variation key="default">
-                                <mask key="constraints">
-                                    <exclude reference="oLv-fc-4QF"/>
-                                </mask>
-                            </variation>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Distance" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sCU-qM-EZl">
                             <rect key="frame" x="40" y="6" width="67" height="20.5"/>

--- a/MSDKUI/Classes/GuidanceNextManeuverView.swift
+++ b/MSDKUI/Classes/GuidanceNextManeuverView.swift
@@ -118,16 +118,8 @@ import UIKit
         distanceLabel.accessibilityLabel = model.accessibilityDistanceFormatter.string(from: model.distance)
         distanceLabel.sizeToFit()
 
-        // When icon is nil, it should be removed (not visible, giving space to the rest of the views)
-        if let icon = model.maneuverIcon {
-            maneuverImageView.isHidden = false
-            maneuverImageView.image = icon
-            maneuverImageHeightConstraint.isActive = true
-        } else {
-            maneuverImageHeightConstraint.isActive = false
-            maneuverImageView.image = nil
-            maneuverImageView.isHidden = true
-        }
+        maneuverImageView.image = model.maneuverIcon
+        updateManeuverImageViewVisibility()
 
         // When ViewModel.streetName is nil, the dot & street name label's should be hidden
         if let streetName = model.streetName {
@@ -151,6 +143,7 @@ import UIKit
         layoutMargins = .zero
 
         loadFromNib()
+        updateManeuverImageViewVisibility()
         setUpLabels()
         setUpViewAccessibility()
 
@@ -186,5 +179,17 @@ import UIKit
             .joined(separator: ", ")
 
         accessibilityHint = hint.isEmpty ? nil : hint
+    }
+
+    /// Updates the maneuver image view visibility based on its image.
+    private func updateManeuverImageViewVisibility() {
+        // When icon is nil, view should be hidden, giving space to the rest of the views
+        if maneuverImageView.image == nil {
+            maneuverImageHeightConstraint.isActive = false
+            maneuverImageView.isHidden = true
+        } else {
+            maneuverImageView.isHidden = false
+            maneuverImageHeightConstraint.isActive = true
+        }
     }
 }


### PR DESCRIPTION
Installs the constraint when loading from nib and configures maneuver
image view visibility at set up. This keeps the height constraint
between rotations.

Signed-off-by: Piotr Marczycki <piotrekm44@users.noreply.github.com>