### PR TITLE
MSDKUI-1706: Refactor GuidanceNextManeuverView

### DIFF
--- a/MSDKUI/Assets/GuidanceNextManeuverView.xib
+++ b/MSDKUI/Assets/GuidanceNextManeuverView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -12,7 +12,6 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="GuidanceNextManeuverView" customModule="MSDKUI" customModuleProvider="target">
             <connections>
                 <outlet property="distanceLabel" destination="sCU-qM-EZl" id="yY3-K1-Hr1"/>
-                <outlet property="maneuverImageHeightConstraint" destination="oLv-fc-4QF" id="l4C-Lo-WAB"/>
                 <outlet property="maneuverImageView" destination="p0e-Lb-zDt" id="hXK-iT-eFc"/>
                 <outlet property="separatorLabel" destination="Al9-lS-4w7" id="wib-7r-khE"/>
                 <outlet property="streetNameLabel" destination="1fM-b3-8Pq" id="2Oi-8G-jCV"/>
@@ -20,21 +19,21 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="48"/>
+            <rect key="frame" x="0.0" y="0.0" width="547" height="170"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="R9j-N6-b1B">
-                    <rect key="frame" x="16" y="8" width="343" height="32"/>
+                    <rect key="frame" x="0.0" y="0.0" width="547" height="162"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="p0e-Lb-zDt">
-                            <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
+                            <rect key="frame" x="0.0" y="65" width="32" height="32"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="32" id="oLv-fc-4QF"/>
                                 <constraint firstAttribute="width" secondItem="p0e-Lb-zDt" secondAttribute="height" multiplier="1:1" id="tSZ-bf-NL7"/>
                             </constraints>
                         </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Distance" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sCU-qM-EZl">
-                            <rect key="frame" x="40" y="6" width="67" height="20.5"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Distance" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sCU-qM-EZl">
+                            <rect key="frame" x="40" y="71" width="67" height="20.5"/>
                             <accessibility key="accessibilityConfiguration">
                                 <bool key="isElement" value="NO"/>
                             </accessibility>
@@ -42,20 +41,17 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" text="·" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Al9-lS-4w7">
-                            <rect key="frame" x="115" y="3" width="10" height="26.5"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" text="・" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Al9-lS-4w7">
+                            <rect key="frame" x="115" y="68" width="22.5" height="26.5"/>
                             <accessibility key="accessibilityConfiguration">
                                 <bool key="isElement" value="NO"/>
                             </accessibility>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="10" id="8w9-ys-Aje"/>
-                            </constraints>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Street" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1fM-b3-8Pq" userLabel="Street Name Label">
-                            <rect key="frame" x="133" y="6" width="210" height="20.5"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Street" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1fM-b3-8Pq" userLabel="Street Name Label">
+                            <rect key="frame" x="145.5" y="71" width="401.5" height="20.5"/>
                             <accessibility key="accessibilityConfiguration">
                                 <bool key="isElement" value="NO"/>
                             </accessibility>
@@ -69,15 +65,15 @@
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstAttribute="bottomMargin" secondItem="R9j-N6-b1B" secondAttribute="bottom" id="N2j-1k-kpp"/>
-                <constraint firstAttribute="trailingMargin" secondItem="R9j-N6-b1B" secondAttribute="trailing" id="WrI-bY-wBZ"/>
-                <constraint firstItem="R9j-N6-b1B" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="topMargin" id="fTx-Ec-a2J"/>
-                <constraint firstItem="R9j-N6-b1B" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" id="msq-pu-gNw"/>
+                <constraint firstAttribute="trailing" secondItem="R9j-N6-b1B" secondAttribute="trailing" id="WrI-bY-wBZ"/>
+                <constraint firstItem="R9j-N6-b1B" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="fTx-Ec-a2J"/>
+                <constraint firstItem="R9j-N6-b1B" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="msq-pu-gNw"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
-            <point key="canvasLocation" x="-140" y="-270.5"/>
+            <point key="canvasLocation" x="-343" y="-680"/>
         </view>
     </objects>
 </document>

--- a/MSDKUI_Demo/GuidanceViewController.swift
+++ b/MSDKUI_Demo/GuidanceViewController.swift
@@ -163,9 +163,6 @@ final class GuidanceViewController: UIViewController {
         // Applies maneuver view style
         setUpManeuverView()
 
-        // Applies next maneuver view style
-        setUpNextManeuverView()
-
         guard let route = route else {
             return
         }
@@ -355,12 +352,6 @@ final class GuidanceViewController: UIViewController {
         // Adds red border
         speedLimitView.layer.borderWidth = 4
         speedLimitView.layer.borderColor = UIColor.red.cgColor
-    }
-
-    /// Styles the next maneuver view.
-    private func setUpNextManeuverView() {
-        // Sets margins for view
-        nextManeuverView.layoutMargins = UIEdgeInsets(top: 8, left: 20, bottom: 8, right: 20)
     }
 
     /// Styles the maneuver view.

--- a/MSDKUI_Demo_Tests/View Controllers/GuidanceViewControllerTests.swift
+++ b/MSDKUI_Demo_Tests/View Controllers/GuidanceViewControllerTests.swift
@@ -101,9 +101,6 @@ final class GuidanceViewControllerTests: XCTestCase {
     func testNextManeuverView() throws {
         XCTAssertNotNil(viewControllerUnderTest?.nextManeuverView, "It has the next maneuver view")
         XCTAssertTrue(try require(viewControllerUnderTest?.nextManeuverView.isHidden), "It has the next maneuver view hidden by default")
-        XCTAssertEqual(try require(viewControllerUnderTest?.nextManeuverView.layoutMargins),
-                       UIEdgeInsets(top: 8, left: 20, bottom: 8, right: 20),
-                       "It has the next maneuver view layout margins correctly set")
     }
 
     /// Checks if the Speed View exists and is configured.

--- a/MSDKUI_Dev/Components/GuidanceNextManeuverSettingsViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceNextManeuverSettingsViewController.swift
@@ -21,52 +21,64 @@ final class GuidanceNextManeuverSettingsViewController: SettingsViewController<G
 
     struct Settings {
         var maneuverIcon: UIImage?
-        var distance: Measurement<UnitLength>
+        var distance: Measurement<UnitLength>?
         var streetName: String?
         var distanceFormatter: MeasurementFormatter
         var foregroundColor: UIColor
-        var textAlignment: NSTextAlignment
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         data = [
-            SettingsItem(title: "Distance, left aligned, red",
+            SettingsItem(title: "Without parameters",
                          configuration: Settings(maneuverIcon: nil,
+                                                 distance: nil,
+                                                 streetName: nil,
+                                                 distanceFormatter: .currentMediumUnitFormatter,
+                                                 foregroundColor: .colorForegroundSecondaryLight)),
+            SettingsItem(title: "With all parameters",
+                         configuration: Settings(maneuverIcon: UIImage(named: "red_sign"),
+                                                 distance: Measurement(value: 12, unit: .kilometers),
+                                                 streetName: "Foobarstrasse 123",
+                                                 distanceFormatter: .currentMediumUnitFormatter,
+                                                 foregroundColor: .colorForegroundSecondaryLight)),
+            SettingsItem(title: "With all parameters (very long address)",
+                         configuration: Settings(maneuverIcon: UIImage(named: "red_sign"),
+                                                 distance: Measurement(value: 12, unit: .kilometers),
+                                                 streetName: "Lorem ipsum dolor sit amet, consectetur adipiscing elit 123",
+                                                 distanceFormatter: .currentMediumUnitFormatter,
+                                                 foregroundColor: .colorForegroundSecondaryLight)),
+            SettingsItem(title: "With all parameters (w/ template image)",
+                         configuration: Settings(maneuverIcon: UIImage(named: "red_sign")?.withRenderingMode(.alwaysTemplate),
+                                                 distance: Measurement(value: 12, unit: .kilometers),
+                                                 streetName: "Foobarstrasse 123",
+                                                 distanceFormatter: .currentMediumUnitFormatter,
+                                                 foregroundColor: .colorForegroundSecondaryLight)),
+            SettingsItem(title: "Without icon",
+                         configuration: Settings(maneuverIcon: nil,
+                                                 distance: Measurement(value: 12, unit: .kilometers),
+                                                 streetName: "Foobarstrasse 123",
+                                                 distanceFormatter: .currentMediumUnitFormatter,
+                                                 foregroundColor: .colorForegroundSecondaryLight)),
+            SettingsItem(title: "Without distance",
+                         configuration: Settings(maneuverIcon: UIImage(named: "red_sign"),
+                                                 distance: nil,
+                                                 streetName: "Foobarstrasse 123",
+                                                 distanceFormatter: .currentMediumUnitFormatter,
+                                                 foregroundColor: .colorForegroundSecondaryLight)),
+            SettingsItem(title: "Without street",
+                         configuration: Settings(maneuverIcon: UIImage(named: "red_sign"),
                                                  distance: Measurement(value: 12, unit: .kilometers),
                                                  streetName: nil,
                                                  distanceFormatter: .currentMediumUnitFormatter,
-                                                 foregroundColor: .red,
-                                                 textAlignment: .left)),
-            SettingsItem(title: "Distance, street name, left aligned, green",
-                         configuration: Settings(maneuverIcon: nil,
-                                                 distance: Measurement(value: 12, unit: .kilometers),
-                                                 streetName: "Foobarstrasse 123",
-                                                 distanceFormatter: .currentMediumUnitFormatter,
-                                                 foregroundColor: .green,
-                                                 textAlignment: .left)),
-            SettingsItem(title: "Icon, distance, street name, left aligned",
+                                                 foregroundColor: .colorForegroundSecondaryLight)),
+            SettingsItem(title: "With all parameters in red",
                          configuration: Settings(maneuverIcon: UIImage(named: "red_sign"),
                                                  distance: Measurement(value: 12, unit: .kilometers),
                                                  streetName: "Foobarstrasse 123",
                                                  distanceFormatter: .currentMediumUnitFormatter,
-                                                 foregroundColor: .colorForegroundSecondaryLight,
-                                                 textAlignment: .left)),
-            SettingsItem(title: "Icon, distance, street name, center aligned, orange",
-                         configuration: Settings(maneuverIcon: UIImage(named: "red_sign"),
-                                                 distance: Measurement(value: 12, unit: .kilometers),
-                                                 streetName: "Foobarstrasse 123",
-                                                 distanceFormatter: .currentMediumUnitFormatter,
-                                                 foregroundColor: .orange,
-                                                 textAlignment: .center)),
-            SettingsItem(title: "Distance, street name, right aligned",
-                         configuration: Settings(maneuverIcon: nil,
-                                                 distance: Measurement(value: 12, unit: .kilometers),
-                                                 streetName: "Foobarstrasse 123",
-                                                 distanceFormatter: .currentMediumUnitFormatter,
-                                                 foregroundColor: .colorForegroundSecondaryLight,
-                                                 textAlignment: .right))
+                                                 foregroundColor: .red))
         ]
     }
 }

--- a/MSDKUI_Dev/Components/GuidanceNextManeuverViewController.swift
+++ b/MSDKUI_Dev/Components/GuidanceNextManeuverViewController.swift
@@ -27,7 +27,6 @@ final class GuidanceNextManeuverViewController: UIViewController {
         settingsViewController?.didSelect = { [weak self] item in
             self?.title = item.title
 
-            self?.nextManeuverView.textAlignment = item.configuration.textAlignment
             self?.nextManeuverView.foregroundColor = item.configuration.foregroundColor
 
             let model = GuidanceNextManeuverView.ViewModel(maneuverIcon: item.configuration.maneuverIcon,

--- a/MSDKUI_Tests/GuidanceNextManeuverViewTests.swift
+++ b/MSDKUI_Tests/GuidanceNextManeuverViewTests.swift
@@ -32,7 +32,7 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
 
     /// Tests if the view has correct layout margins set.
     func testLayoutMargins() {
-        XCTAssertEqual(nextManeuverView.layoutMargins, UIEdgeInsets.zero, "It has correct layout margins")
+        XCTAssertEqual(nextManeuverView.layoutMargins, .zero, "It has correct layout margins")
     }
 
     /// Tests if the view has the distance label with empty content by default.
@@ -40,15 +40,13 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
         XCTAssertNotNil(nextManeuverView.distanceLabel, "It has the distance label")
         XCTAssertNil(nextManeuverView.distanceLabel.text, "It doesn't show the distance text")
         XCTAssertEqual(nextManeuverView.distanceLabel.textColor, nextManeuverView.foregroundColor, "It has the correct text color")
-        XCTAssertEqual(nextManeuverView.distanceLabel.textAlignment, .left, "It has the correct text alignment")
     }
 
     /// Tests if the view has the distance/street name separator.
     func testHasSeparatorLabel() {
         XCTAssertNotNil(nextManeuverView.separatorLabel, "It has the separator label")
-        XCTAssertEqual(nextManeuverView.separatorLabel.text, "·", "It has the correct separator character")
+        XCTAssertEqual(nextManeuverView.separatorLabel.text, "・", "It has the correct separator character")
         XCTAssertEqual(nextManeuverView.separatorLabel.textColor, nextManeuverView.foregroundColor, "It has the correct text color")
-        XCTAssertEqual(nextManeuverView.separatorLabel.textAlignment, .center, "It has the correct text alignment")
         XCTAssertTrue(nextManeuverView.separatorLabel.isHidden, "It is hidden by default")
     }
 
@@ -57,58 +55,62 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
         XCTAssertNotNil(nextManeuverView.streetNameLabel, "It has the street name label")
         XCTAssertNil(nextManeuverView.streetNameLabel.text, "It doesn't show the street name text")
         XCTAssertEqual(nextManeuverView.streetNameLabel.textColor, nextManeuverView.foregroundColor, "It has the correct text color")
-        XCTAssertEqual(nextManeuverView.streetNameLabel.textAlignment, .left, "It has the correct text alignment")
     }
 
     // MARK: - Configure
 
     /// Tests if the subview visibilities are correct when model is populated with a complete model.
-    func testSubviewVisibilitiesWhenModelIsComplete() {
+    func testConfigureWhenModeIsComplete() {
         let distance = Measurement<UnitLength>(value: 100, unit: .meters)
-        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(),
-                                                           distance: distance,
-                                                           streetName: "Invalidenstr.")
+        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(), distance: distance, streetName: "Foobarstrasse 123")
 
         nextManeuverView.configure(with: viewModel)
 
         XCTAssertFalse(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is visible")
         XCTAssertNotNil(nextManeuverView.maneuverImageView.image, "The maneuver icon is set")
-        XCTAssertTrue(nextManeuverView.maneuverImageHeightConstraint.isActive, "The maneuver icon height constraint is active")
         XCTAssertFalse(nextManeuverView.distanceLabel.isHidden, "The distance label is visible")
         XCTAssertFalse(nextManeuverView.separatorLabel.isHidden, "The separator label is visible")
         XCTAssertFalse(nextManeuverView.streetNameLabel.isHidden, "The street name label is visible")
     }
 
-    /// Tests if the subview visibilities are correct when model is populated with an incomplete model.
-    func testSubviewVisibilitiesWhenModelIsIncomplete() {
+    /// Tests if the subview visibilities are correct when model misses street name.
+    func testConfigureWhenStreetNameIsMissing() {
         let distance = Measurement<UnitLength>(value: 100, unit: .meters)
-        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(),
-                                                           distance: distance,
-                                                           streetName: nil)
+        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(), distance: distance, streetName: nil)
 
         nextManeuverView.configure(with: viewModel)
 
         XCTAssertFalse(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is visible")
         XCTAssertNotNil(nextManeuverView.maneuverImageView.image, "The maneuver icon is set")
-        XCTAssertTrue(nextManeuverView.maneuverImageHeightConstraint.isActive, "The maneuver icon height constraint is active")
         XCTAssertFalse(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is visible")
         XCTAssertFalse(nextManeuverView.distanceLabel.isHidden, "The distance label is visible")
         XCTAssertTrue(nextManeuverView.separatorLabel.isHidden, "The separator label is hidden")
         XCTAssertTrue(nextManeuverView.streetNameLabel.isHidden, "The street name label is hidden")
     }
 
-    /// Tests if container image view is hidden when model is populated without icon view.
-    func testIconVisibilityWhenNotAvailable() {
+    /// Tests if the subview visibilities are correct when model misses distance.
+    func testConfigureWhenDistanceIsMissing() {
+        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(), distance: nil, streetName: "Foobarstrasse 123")
+
+        nextManeuverView.configure(with: viewModel)
+
+        XCTAssertFalse(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is visible")
+        XCTAssertNotNil(nextManeuverView.maneuverImageView.image, "The maneuver icon is set")
+        XCTAssertFalse(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is visible")
+        XCTAssertTrue(nextManeuverView.distanceLabel.isHidden, "The distance label is hidden")
+        XCTAssertTrue(nextManeuverView.separatorLabel.isHidden, "The separator label is hidden")
+        XCTAssertFalse(nextManeuverView.streetNameLabel.isHidden, "The street name label is visible")
+    }
+
+    /// Tests if the subview visibilities are correct when model misses icon.
+    func testConfigureWhenIconIsMissing() {
         let distance = Measurement<UnitLength>(value: 100, unit: .meters)
-        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: nil,
-                                                           distance: distance,
-                                                           streetName: "Invalidenstr.")
+        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: nil, distance: distance, streetName: "Foobarstrasse 123")
 
         nextManeuverView.configure(with: viewModel)
 
         XCTAssertTrue(nextManeuverView.maneuverImageView.isHidden, "The maneuver icon is hidden")
         XCTAssertNil(nextManeuverView.maneuverImageView.image, "The maneuver icon is not set")
-        XCTAssertFalse(nextManeuverView.maneuverImageHeightConstraint.isActive, "The maneuver icon height constraint is inactive")
         XCTAssertFalse(nextManeuverView.distanceLabel.isHidden, "The distance label is visible")
         XCTAssertFalse(nextManeuverView.separatorLabel.isHidden, "The separator label is visible")
         XCTAssertFalse(nextManeuverView.streetNameLabel.isHidden, "The street name label is visible")
@@ -132,15 +134,11 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
     func testViewAccessibility() {
         XCTAssertTrue(nextManeuverView.isAccessibilityElement,
                       "It allows accessibility access")
-        XCTAssertEqual(nextManeuverView.accessibilityTraits,
-                       .staticText,
+        XCTAssertEqual(nextManeuverView.accessibilityTraits, .staticText,
                        "It has the correct accessibility traits")
-        XCTAssertEqual(nextManeuverView.accessibilityIdentifier,
-                       "MSDKUI.GuidanceNextManeuverView",
+        XCTAssertEqual(nextManeuverView.accessibilityIdentifier, "MSDKUI.GuidanceNextManeuverView",
                        "It has the correct accessibility identifier")
-        XCTAssertLocalized(nextManeuverView.accessibilityLabel,
-                           key: "msdkui_next_maneuver",
-                           bundle: .MSDKUI,
+        XCTAssertLocalized(nextManeuverView.accessibilityLabel, key: "msdkui_next_maneuver", bundle: .MSDKUI,
                            "It has the correct accessibility label")
     }
 
@@ -152,9 +150,7 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
     /// Tests if the view accessibility hint is correct when model is populated with the default distance formatter.
     func testViewAccessibilityHintWithDefaultDistanceFormatter() {
         let distance = Measurement<UnitLength>(value: 100, unit: .meters)
-        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(),
-                                                           distance: distance,
-                                                           streetName: "Invalidenstr.")
+        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(), distance: distance, streetName: "Foobarstrasse 123")
 
         nextManeuverView.configure(with: viewModel)
 
@@ -168,9 +164,7 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
     /// with the default distance formatter.
     func testViewDistanceLabelAccessibilityLabelWithDefaultDistanceFormatter() {
         let distance = Measurement<UnitLength>(value: 100, unit: .meters)
-        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(),
-                                                           distance: distance,
-                                                           streetName: "Invalidenstr.")
+        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(), distance: distance, streetName: "Foobarstrasse 123")
 
         nextManeuverView.configure(with: viewModel)
 
@@ -185,7 +179,7 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
         let distanceFormatter = MeasurementFormatter()
         let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(),
                                                            distance: distance,
-                                                           streetName: "Invalidenstr.",
+                                                           streetName: "Foobarstrasse 123",
                                                            distanceFormatter: distanceFormatter)
 
         nextManeuverView.configure(with: viewModel)
@@ -203,7 +197,7 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
         let distanceFormatter = MeasurementFormatter()
         let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(),
                                                            distance: distance,
-                                                           streetName: "Invalidenstr.",
+                                                           streetName: "Foobarstrasse 123",
                                                            accessibilityDistanceFormatter: distanceFormatter)
 
         nextManeuverView.configure(with: viewModel)
@@ -216,9 +210,7 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
     /// Tests if the view accessibility hint is correct when model is populated with an incomplete model.
     func testViewAccessibilityHintWhenModelIsIncomplete() {
         let distance = Measurement<UnitLength>(value: 100, unit: .meters)
-        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(),
-                                                           distance: distance,
-                                                           streetName: nil)
+        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(), distance: distance, streetName: nil)
 
         nextManeuverView.configure(with: viewModel)
 
@@ -235,31 +227,9 @@ final class GuidanceNextManeuverViewTests: XCTestCase {
 
         nextManeuverView.foregroundColor = testForegroundColor
 
-        // Make sure that the labels switch to the new foregroundColor
         XCTAssertEqual(nextManeuverView.distanceLabel.textColor, testForegroundColor, "It sets the correct foreground color for the view")
         XCTAssertEqual(nextManeuverView.separatorLabel.textColor, testForegroundColor, "It sets the correct foreground color for the view")
         XCTAssertEqual(nextManeuverView.streetNameLabel.textColor, testForegroundColor, "It sets the correct foreground color for the view")
-
-        // Make sure that the icon is tinted with the new foregroundColor
-        let distance = Measurement<UnitLength>(value: 100, unit: .meters)
-        let viewModel = GuidanceNextManeuverView.ViewModel(maneuverIcon: UIImage(),
-                                                           distance: distance,
-                                                           streetName: nil)
-
-        nextManeuverView.configure(with: viewModel)
-
         XCTAssertEqual(nextManeuverView.maneuverImageView.tintColor, testForegroundColor, "It sets the correct foreground color for the view")
-    }
-
-    /// Tests the behavior when the `.textAlignment` property is set.
-    func testWhenTextAlignmentIsSet() {
-        nextManeuverView.textAlignment = .right
-
-        // Make sure that the distanceLabel & streetNameLabel switch to the new text alignment
-        XCTAssertEqual(nextManeuverView.distanceLabel.textAlignment, .right, "It sets the correct text alignment for the distance label")
-        XCTAssertEqual(nextManeuverView.streetNameLabel.textAlignment, .right, "It sets the correct text alignment for the street name label")
-
-        // Note that the separatorLabel.textAlignment should not be updated at all
-        XCTAssertEqual(nextManeuverView.separatorLabel.textAlignment, .center, "It sets the correct text alignment for the street name label")
     }
 }


### PR DESCRIPTION
* Remove text alignment
* Remove inset from component. Margins should be added by developers around the component (if needed).
* Adapt the size based on the content
* Hide separator (dot) in case street or address is missing