### PR TITLE
MSDKUI-1684: Fix warning icon after device orientation

### DIFF
--- a/MSDKUI/Assets/RouteDescriptionItem.xib
+++ b/MSDKUI/Assets/RouteDescriptionItem.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -61,15 +61,15 @@
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="252" verticalHuggingPriority="252" translatesAutoresizingMaskIntoConstraints="NO" id="vgL-h2-n5o">
-                                            <rect key="frame" x="82.5" y="5" width="15" height="14"/>
+                                        <imageView hidden="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="252" verticalHuggingPriority="252" translatesAutoresizingMaskIntoConstraints="NO" id="vgL-h2-n5o">
+                                            <rect key="frame" x="78.5" y="5" width="15" height="14"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="14" id="kWw-ly-zot"/>
                                                 <constraint firstAttribute="width" constant="15" id="wUD-CQ-8LP"/>
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Delay" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumScaleFactor="0.75" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="O4l-jF-BPt">
-                                            <rect key="frame" x="105.5" y="4.5" width="177.5" height="18"/>
+                                            <rect key="frame" x="82.5" y="4.5" width="200.5" height="18"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                             <color key="textColor" red="1" green="0.50196081400000003" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
@@ -137,7 +137,7 @@
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="-70" y="-291"/>
+            <point key="canvasLocation" x="-260" y="-372"/>
         </view>
     </objects>
 </document>

--- a/MSDKUI/Classes/RouteDescriptionItem.swift
+++ b/MSDKUI/Classes/RouteDescriptionItem.swift
@@ -395,10 +395,13 @@ import NMAKit
 
     /// Refreshes the view based on the visible sections.
     private func refresh() {
+        let warningImage = UIImage(named: "RouteDescriptionItem.warning", in: .MSDKUI, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
+
         transportModeView.isHidden = !isSectionVisible(.icon)
         durationLabel.isHidden = !isSectionVisible(.duration)
         delayLabel.isHidden = !isSectionVisible(.delay) || (delayLabel.attributedText?.length ?? 0) == 0
         warningIcon.isHidden = handler != nil && handler.hasDelay ? delayLabel.isHidden : true
+        warningIcon.image = warningIcon.isHidden ? nil : warningImage
         barView.isHidden = !isSectionVisible(.bar)
         lengthLabel.isHidden = !isSectionVisible(.length)
         timeLabel.isHidden = !isSectionVisible(.time)
@@ -421,8 +424,6 @@ import NMAKit
         primaryLabelColor = .colorForeground
         warningColor = .colorAlert
         secondaryLabelsColor = .colorForegroundSecondary
-
-        warningIcon.image = UIImage(named: "RouteDescriptionItem.warning", in: .MSDKUI, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
     }
 
     /// Sets the accessibility stuff.

--- a/MSDKUI_Tests/RouteDescriptionItemTests.swift
+++ b/MSDKUI_Tests/RouteDescriptionItemTests.swift
@@ -20,14 +20,7 @@ import XCTest
 final class RouteDescriptionItemTests: XCTestCase {
 
     /// The object under test.
-    private var itemUnterTest: RouteDescriptionItem?
-
-    override func setUp() {
-        super.setUp()
-
-        // Set up the item
-        itemUnterTest = RouteDescriptionItem()
-    }
+    private let itemUnterTest = RouteDescriptionItem()
 
     // MARK: - Tests
 
@@ -51,6 +44,11 @@ final class RouteDescriptionItemTests: XCTestCase {
         XCTAssertEqual(item.lengthLabel.textColor, .colorForegroundSecondary, "It has the correct length label text color")
         XCTAssertEqual(item.timeLabel.textColor, .colorForegroundSecondary, "It has the correct time label text color")
         XCTAssertEqual(item.warningIcon.tintColor, .colorAlert, "It has the correct warning icon tint color")
+    }
+
+    /// Tests the warning icon image view right after item initialization.
+    func testWarningIcon() throws {
+        XCTAssertTrue(try require(itemUnterTest.warningIcon.isHidden), "It is hidden by default after item initialization")
     }
 
     /// Tests visibility modifications.


### PR DESCRIPTION
Originally, `RouteDescriptionItem` had an icon by default. With this commit, `RouteDescriptionItem` checks if the icon is required  before showing it.