### PR TITLE
MSDKUI-1903: Handle NMANavigationManagerInvalidValue

### DIFF
--- a/MSDKUI/Classes/GuidanceManeuverMonitor.swift
+++ b/MSDKUI/Classes/GuidanceManeuverMonitor.swift
@@ -116,7 +116,10 @@ open class GuidanceManeuverMonitor: NSObject {
         // Try to set the distance
         if NMAPositioningManager.sharedInstance().currentPosition != nil {
             let distanceValue = NMANavigationManager.sharedInstance().distanceToCurrentManeuver
-            data.distance = Measurement(value: Double(distanceValue), unit: UnitLength.meters)
+
+            if distanceValue != NMANavigationManagerInvalidValue {
+                data.distance = Measurement(value: Double(distanceValue), unit: UnitLength.meters)
+            }
         }
 
         // Try to set the info1 and info2 strings.


### PR DESCRIPTION
NMANavigationManager.sharedInstance().distanceToCurrentManeuver returns NMANavigationManagerInvalidValue for invalid distance to next maneuver.

This commit address this issue.