### PR TITLE
MSDKUI-1934: Fix image width in GuidanceNextManeuverView

### DIFF
--- a/MSDKUI/Assets/GuidanceNextManeuverView.xib
+++ b/MSDKUI/Assets/GuidanceNextManeuverView.xib
@@ -29,7 +29,7 @@
                             <rect key="frame" x="0.0" y="65" width="32" height="32"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="32" id="oLv-fc-4QF"/>
-                                <constraint firstAttribute="width" secondItem="p0e-Lb-zDt" secondAttribute="height" multiplier="1:1" id="tSZ-bf-NL7"/>
+                                <constraint firstAttribute="width" constant="32" id="rCm-W3-ZUp"/>
                             </constraints>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Distance" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sCU-qM-EZl">


### PR DESCRIPTION
Uses a different constraint for the image width. Instead of setting the width size as 1:1 to height, this fix hardcodes the width to the correct value.