### PR TITLE
MSDKUI-1961: Update Podfile.lock for example apps

### DIFF
--- a/Documentation/Guides_Examples/HelloMSDKUI/Podfile.lock
+++ b/Documentation/Guides_Examples/HelloMSDKUI/Podfile.lock
@@ -4,20 +4,17 @@ PODS:
     - HEREMaps (= 3.10.1)
 
 DEPENDENCIES:
-  - HEREMapsUI (from `../../../`)
+  - HEREMapsUI (= 2.1.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - HEREMaps
-
-EXTERNAL SOURCES:
-  HEREMapsUI:
-    :path: "../../../"
+    - HEREMapsUI
 
 SPEC CHECKSUMS:
   HEREMaps: 223c0a85c61b4336fb31c45160c249bb1625a0e3
   HEREMapsUI: d82d5246fc5942ed49383129135a38c33df0daca
 
-PODFILE CHECKSUM: dc931bf0dd4c77a3e65ce14b2e88d090cf10581f
+PODFILE CHECKSUM: e49df25d859c3b55231e92e60778c8b6f9359d95
 
-COCOAPODS: 1.6.0.beta.2
+COCOAPODS: 1.6.1

--- a/Documentation/Guides_Examples/MSDKUIPrimer/Podfile.lock
+++ b/Documentation/Guides_Examples/MSDKUIPrimer/Podfile.lock
@@ -4,20 +4,17 @@ PODS:
     - HEREMaps (= 3.10.1)
 
 DEPENDENCIES:
-  - HEREMapsUI (from `../../../`)
+  - HEREMapsUI (= 2.1.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - HEREMaps
-
-EXTERNAL SOURCES:
-  HEREMapsUI:
-    :path: "../../../"
+    - HEREMapsUI
 
 SPEC CHECKSUMS:
   HEREMaps: 223c0a85c61b4336fb31c45160c249bb1625a0e3
   HEREMapsUI: d82d5246fc5942ed49383129135a38c33df0daca
 
-PODFILE CHECKSUM: 2b8bb8e26f8c184222a8b52b456dd634701ea79b
+PODFILE CHECKSUM: f07a650e9c5a3531d063ca01558fc2f2cc2d8677
 
-COCOAPODS: 1.6.0.beta.2
+COCOAPODS: 1.6.1


### PR DESCRIPTION
This PR uses the correct CocoaPods version (as specified via `Gemfile`) to install the pods (using `bundle exec pod install` instead of `pod install`) and removes local references (as it uses the public podspec rather than the local one).