### PR TITLE
FIXED: Speed limit is not accurate in HEREMap UI

### DIFF
--- a/MSDKUI/Classes/ExtensionMeasurementFormatter.swift
+++ b/MSDKUI/Classes/ExtensionMeasurementFormatter.swift
@@ -48,7 +48,7 @@ extension MeasurementFormatter {
         formatter.unitOptions = .providedUnit
         formatter.unitStyle = .short
         formatter.locale = .current
-        formatter.numberFormatter = .roundUpFormatter
+        formatter.numberFormatter = .roundHalfUpFormatter
         return formatter
     }()
 
@@ -58,7 +58,7 @@ extension MeasurementFormatter {
         formatter.unitOptions = .providedUnit
         formatter.unitStyle = .long
         formatter.locale = .current
-        formatter.numberFormatter = .roundUpFormatter
+        formatter.numberFormatter = .roundHalfUpFormatter
         return formatter
     }()
 }

--- a/MSDKUI/Classes/ExtensionNumberFormatter.swift
+++ b/MSDKUI/Classes/ExtensionNumberFormatter.swift
@@ -18,10 +18,10 @@ import Foundation
 
 extension NumberFormatter {
 
-    /// Returns a `NumberFormatter` that rounds up to the closest integer.
-    static let roundUpFormatter: NumberFormatter = {
+    /// Returns a `NumberFormatter` that rounds up to the closest integer, or away from zero if equidistant.
+    static let roundHalfUpFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
-        formatter.roundingMode = .up
+        formatter.roundingMode = .halfUp
         formatter.maximumFractionDigits = 0
         return formatter
     }()

--- a/MSDKUI/Classes/GuidanceSpeedLimitView.swift
+++ b/MSDKUI/Classes/GuidanceSpeedLimitView.swift
@@ -95,7 +95,7 @@ import UIKit
         let convertedSpeed = speedLimit?.converted(to: unit)
         let speedValue = convertedSpeed.map { NSNumber(value: $0.value) }
 
-        speedLimitLabel.text = speedValue.flatMap(NumberFormatter.roundUpFormatter.string)
+        speedLimitLabel.text = speedValue.flatMap(NumberFormatter.roundHalfUpFormatter.string)
         speedLimitLabel.textColor = speedLimitTextColor
 
         accessibilityHint = convertedSpeed.map(MeasurementFormatter.longSpeedFormatter.string)

--- a/MSDKUI/Classes/GuidanceSpeedView.swift
+++ b/MSDKUI/Classes/GuidanceSpeedView.swift
@@ -114,7 +114,7 @@ import UIKit
         let speedValue = convertedSpeed.flatMap { NSNumber(value: $0.value) }
 
         // Sets the labels information.
-        speedValueLabel.text = speedValue.flatMap(NumberFormatter.roundUpFormatter.string) ?? .missingValue
+        speedValueLabel.text = speedValue.flatMap(NumberFormatter.roundHalfUpFormatter.string) ?? .missingValue
         speedUnitLabel.text = speed != nil ? MeasurementFormatter.shortSpeedFormatter.string(from: unit) : nil
 
         // Sets the labels colors.

--- a/MSDKUI_Tests/ExtensionNumberFormatterTests.swift
+++ b/MSDKUI_Tests/ExtensionNumberFormatterTests.swift
@@ -18,12 +18,12 @@
 import XCTest
 
 final class ExtensionNumberFormatterTests: XCTestCase {
-    /// Tests `NumberFormatter.roundUpFormatter`.
-    func testRoundUpFormatter() {
-        let formatter = NumberFormatter.roundUpFormatter
+    /// Tests `NumberFormatter.roundHalfUpFormatter`.
+    func testRoundHalfUpFormatter() {
+        let formatter = NumberFormatter.roundHalfUpFormatter
 
         XCTAssertEqual(formatter.string(from: NSNumber(value: 6.0)), "6", "It returns the correct rounded up string")
-        XCTAssertEqual(formatter.string(from: NSNumber(value: 6.1)), "7", "It returns the correct rounded up string")
+        XCTAssertEqual(formatter.string(from: NSNumber(value: 6.1)), "6", "It returns the correct rounded up string")
         XCTAssertEqual(formatter.string(from: NSNumber(value: 6.5)), "7", "It returns the correct rounded up string")
         XCTAssertEqual(formatter.string(from: NSNumber(value: 6.9)), "7", "It returns the correct rounded up string")
         XCTAssertEqual(formatter.string(from: NSNumber(value: 7.0)), "7", "It returns the correct rounded up string")

--- a/MSDKUI_Tests/GuidanceSpeedLimitViewTests.swift
+++ b/MSDKUI_Tests/GuidanceSpeedLimitViewTests.swift
@@ -109,9 +109,9 @@ final class GuidanceSpeedLimitViewTests: XCTestCase {
         speedLimitView.unit = .knots
         speedLimitView.speedLimit = Measurement(value: 80, unit: UnitSpeed.kilometersPerHour)
 
-        XCTAssertEqual(speedLimitView.speedLimitLabel.text, "44", "It shows the correct speed value")
+        XCTAssertEqual(speedLimitView.speedLimitLabel.text, "43", "It shows the correct speed value")
         XCTAssertEqual(speedLimitView.speedLimitLabel.textColor, .colorForeground, "It shows the label with correct color")
-        XCTAssertEqual(speedLimitView.accessibilityHint, "44 knots", "It returns the correct hint")
+        XCTAssertEqual(speedLimitView.accessibilityHint, "43 knots", "It returns the correct hint")
     }
 
     /// Test if the background image view shows the correct image when set.
@@ -150,6 +150,6 @@ final class GuidanceSpeedLimitViewTests: XCTestCase {
 
         speedLimitView.unit = .knots
 
-        XCTAssertEqual(speedLimitView.speedLimitLabel.text, "44", "It shows the correct speed value after the change")
+        XCTAssertEqual(speedLimitView.speedLimitLabel.text, "43", "It shows the correct speed value after the change")
     }
 }

--- a/MSDKUI_Tests/GuidanceSpeedViewTests.swift
+++ b/MSDKUI_Tests/GuidanceSpeedViewTests.swift
@@ -107,11 +107,11 @@ final class GuidanceSpeedViewTests: XCTestCase {
         speedView.unit = .knots
         speedView.speed = Measurement(value: 10, unit: UnitSpeed.kilometersPerHour)
 
-        XCTAssertEqual(speedView.speedValueLabel.text, "6", "It shows the correct speed value")
+        XCTAssertEqual(speedView.speedValueLabel.text, "5", "It shows the correct speed value")
         XCTAssertEqual(speedView.speedUnitLabel.text, "kn", "It shows the correct speed unit")
         XCTAssertEqual(speedView.speedValueLabel.textColor, .colorForeground, "It shows the label with correct color")
         XCTAssertEqual(speedView.speedUnitLabel.textColor, .colorForegroundSecondary, "It shows the label with correct color")
-        XCTAssertEqual(speedView.accessibilityHint, "6 knots", "It returns the correct hint")
+        XCTAssertEqual(speedView.accessibilityHint, "5 knots", "It returns the correct hint")
     }
 
     /// Tests if the labels are correct when `.speedValueTextColor` and `.speedUnitTextColor` are changed.
@@ -137,7 +137,7 @@ final class GuidanceSpeedViewTests: XCTestCase {
 
         speedView.unit = .knots
 
-        XCTAssertEqual(speedView.speedValueLabel.text, "6", "It shows the correct speed value after the change")
+        XCTAssertEqual(speedView.speedValueLabel.text, "5", "It shows the correct speed value after the change")
         XCTAssertEqual(speedView.speedUnitLabel.text, "kn", "It shows the correct speed unit after the change")
     }
 


### PR DESCRIPTION
Speed limit formatter replaced with the one with NumberFormatter.RoundingMode.halfUp rounding method - same as in Android.